### PR TITLE
sys/stat.h required on UNIX systems for mkdir()

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -13,6 +13,7 @@
 #include <cstdio>
 #include <cstdlib>
 #include <ctime>
+#include <sys/stat.h>
 #ifdef _DEBUG
 #include <cassert>
 #endif


### PR DESCRIPTION
Just a quick fix I had to add to get it to compile. It works fine with the addition of this #include.
