### PR TITLE
Example of how to display a map using OpenLayer instead of google maps.

### DIFF
--- a/contrib/openlayers/README.md
+++ b/contrib/openlayers/README.md
@@ -1,0 +1,20 @@
+#OpenLayers + mcmap#
+This is a simple example of how you could start using mcmap with [OpenLayers](http://openlayers.org).
+OpenLayers makes it easy to put a dynamic map in any web page. It can display map tiles and markers loaded from any source. 
+OpenLayers has been developed to further the use of geographic information of all kinds. 
+OpenLayers is completely free, Open Source JavaScript, released under the 2-clause BSD License (also known as the FreeBSD).
+
+
+##Instructions##
+This will work on Linux if you have ImageMagic and pngcrush installed.
+
+* Make sure mcmap is in your path or edit render.sh
+* $>./render.sh
+* open mcmap.html in a web browser.
+  The browser must support loading from local files or you have to put mcmap.html and the tiles folder that will be crated on a web server
+
+
+
+##TODO##
+* Make stuff use some sort of usable coordinate system and don't let openlayers guess it
+

--- a/contrib/openlayers/mcmap.html
+++ b/contrib/openlayers/mcmap.html
@@ -1,0 +1,35 @@
+<html>
+<head>
+  <title>mcmap Sample</title>
+    <script src="http://openlayers.org/api/OpenLayers.js"></script>
+    <script src="http://code.jquery.com/jquery-1.6.4.min.js"></script>
+    <script defer="defer" type="text/javascript">
+	var map;
+	
+	$(document).ready(function(){
+		init();
+	});
+	
+	function init(){
+        	map = new OpenLayers.Map('map', {
+			numZoomLevels:6,
+			eventListeners: {
+				"zoomend": mapEvent,
+				"moveend": mapEvent
+			}
+		});
+        	var xyz = new OpenLayers.Layer.XYZ("mcmap Layer", "./tiles/x${x}y${y}z${z}.png");
+        	map.addLayer(xyz);
+        	map.zoomToMaxExtent();
+	}
+
+	function mapEvent(event){
+	    $(".zoomLevel").html(map.getZoom());	
+	}
+      </script>
+    </head>
+    <body>
+      <p>Zoom:<span class="zoomLevel"></span></p>
+      <div style="width:100%; height:100%; border:1px solid black;" id="map"></div>
+    </body>
+</html>

--- a/contrib/openlayers/render.sh
+++ b/contrib/openlayers/render.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+#first argument should be the world
+WORLD=$1
+# where can we find mcmap
+MCMAPBIN="mcmap"
+# where shoud we put the processed tiles
+TILESDIR="`pwd`/tiles"
+# where do we put the raw tiles
+RAWTILESDIR="`pwd`/tmp"
+
+function usage(){
+	echo "Usage:"
+	echo $0 "<path to world>"
+}
+
+if [[ ! -d $WORLD ]] ; then
+  usage
+  exit 1
+fi 
+
+#make some folders to store stuff
+if [[ ! -d $TILESDIR ]] ; then
+	mkdir -p $TILESDIR
+fi
+if [[ ! -d $RAWTILESDIR ]] ; then
+	mkdir -p $RAWTILESDIR
+fi
+
+
+#generate the raw tiles
+$MCMAPBIN -split $RAWTILESDIR $WORLD
+
+#process all raw tiles
+echo "Processing raw tiles"
+for SRC in $RAWTILESDIR/*.png ; do
+	FILE="`basename $SRC`"
+	#default tile size for OpenLayers is 256x256 pixels
+	convert -scale 256 $SRC $TILESDIR/$FILE 
+done
+echo "Done"
+


### PR DESCRIPTION
Use it if you want to.
It basically resizes all tiles produced using split to 256x256 pixels (which openlayers want by default) and then displays them. This reduces the data needed to be downloaded to the browser somewhat.
