### PR TITLE
Fix for X11 (libpng) dependency in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # if you don't want png support, remove "-DWITHPNG", "-lpng" and "draw_png.cpp" below
 CC=g++
-CFLAGS=-O3 -c -Wall -fomit-frame-pointer -pedantic -DWITHPNG -I/usr/local/include
-LDFLAGS=-O3 -lz -lpng -fomit-frame-pointer -L/usr/local/lib
+CFLAGS=-O3 -c -Wall -fomit-frame-pointer -pedantic -DWITHPNG -I/usr/local/include -I/usr/X11/include
+LDFLAGS=-O3 -lz -lpng -fomit-frame-pointer -L/usr/local/lib -L/usr/X11/lib
 DCFLAGS=-g -O0 -c -Wall -D_DEBUG -DWITHPNG -I/usr/local/include
 DLDFLAGS=-g -O0 -lz -lpng -L/usr/local/lib
 SOURCES=main.cpp helper.cpp nbt.cpp colors.cpp worldloader.cpp filesystem.cpp globals.cpp draw_png.cpp extractcolors.cpp pngreader.cpp


### PR DESCRIPTION
mcmap wasn't building on OSX, I've fixed the Makefile for the X11 (libpng) dependency
