### PR TITLE
Add the ability to render MystCraft ages

### DIFF
--- a/globals.cpp
+++ b/globals.cpp
@@ -31,3 +31,5 @@ Marker g_Markers[MAX_MARKERS];
 char *g_TilePath = NULL;
 
 int8_t g_SectionMin, g_SectionMax;
+
+uint8_t g_MystCraftAge;

--- a/globals.h
+++ b/globals.h
@@ -61,4 +61,6 @@ extern char *g_TilePath;
 
 extern int8_t g_SectionMin, g_SectionMax;
 
+extern uint8_t g_MystCraftAge;
+
 #endif

--- a/main.cpp
+++ b/main.cpp
@@ -253,6 +253,12 @@ int main(int argc, char **argv)
 				marker.offsetX = x - (marker.chunkX * CHUNKSIZE_X);
 				marker.offsetZ = z - (marker.chunkZ * CHUNKSIZE_Z);
 				g_MarkerCount++;
+            } else if (strcmp(option, "-mystcraftage") == 0) {
+                if (!MOREARGS(1)) {
+                    printf("Error: %s needs an integer age number argument", option);
+                    return 1;
+                }
+                g_MystCraftAge = atoi(NEXTARG);
 			} else {
 				filename = (char *) option;
 			}
@@ -326,7 +332,15 @@ int main(int argc, char **argv)
 			return 1;
 		}
 		filename = tmp;
-	}
+	} else if (g_MystCraftAge) {
+        char *tmp = new char[strlen(filename) + 20];
+        sprintf(tmp, "%s/DIM_MYST%d", filename, g_MystCraftAge);
+		if (!dirExists(tmp)) {
+			printf("Error: This world does not have Age %d!\n", g_MystCraftAge);
+			return 1;
+		}
+        filename = tmp;
+    }
 	// Figure out whether this is the old save format or McRegion or Anvil
 	g_WorldFormat = getWorldFormat(filename);
 


### PR DESCRIPTION
Add the ability to render ages created by the [MystCraft](http://www.minecraftforum.net/topic/918541-151-mystcraft-0102/) mod.  This adds a "-mystcraftage _n_" option which specifies the age to be rendered.  It processes that parameter much the same way the "-nether" and "-end" parameters are handled.
