### PR TITLE
Rendering overhaul

### DIFF
--- a/canvas.cpp
+++ b/canvas.cpp
@@ -128,12 +128,13 @@ void IsometricCanvas::drawChunk(const Terrain::Data &terrain,
   else
     interpreter = blockAtPost116;
 
-  for (uint8_t yPos = (height & 0x0f); yPos < (height >> 4); yPos++) {
+  const uint8_t minSection = std::max((map.minY >> 4), (height & 0x0f));
+  const uint8_t maxSection = std::min((map.maxY >> 4) + 1, (height >> 4));
+
+  for (uint8_t yPos = minSection; yPos < maxSection; yPos++) {
     drawSection(chunk["Level"]["Sections"][yPos], xPos, zPos, yPos,
                 interpreter);
   }
-
-  return;
 }
 
 void IsometricCanvas::drawSection(const NBT &section, const int64_t xPos,
@@ -164,9 +165,13 @@ void IsometricCanvas::drawSection(const NBT &section, const int64_t xPos,
     }
   }
 
+  const uint8_t minY = (map.minY < (yPos << 4) ? 0 : map.minY - (yPos << 4));
+  const uint8_t maxY =
+      ((yPos + 1) << 4 > map.maxY ? map.maxY - (yPos << 4) + 1 : 16);
+
   for (uint8_t x = 0; x < 16; x++) {
     for (uint8_t z = 0; z < 16; z++) {
-      for (uint8_t y = 0; y < 16; y++) {
+      for (uint8_t y = minY; y < maxY; y++) {
         int16_t index = interpreter(section, x, z, y);
 
         if (index >= colorIndex) {

--- a/canvas.cpp
+++ b/canvas.cpp
@@ -176,12 +176,18 @@ void IsometricCanvas::drawSection(const NBT &section, const int64_t xPos,
     }
   }
 
+  const uint64_t length =
+      std::max((uint64_t)ceil(log2(section["Palette"].size())), (uint64_t)4);
+
+  const std::vector<int64_t> *blockStates =
+      section["BlockStates"].get<const std::vector<int64_t> *>();
+
   for (uint8_t x = 0; x < 16; x++) {
     for (uint8_t z = 0; z < 16; z++) {
       for (uint8_t y = 0; y < 16; y++) {
         uint8_t xReal = x, zReal = z;
         orient(xReal, zReal, map.orientation);
-        index = interpreter(section, xReal, zReal, y);
+        index = interpreter(length, blockStates, xReal, zReal, y);
 
         if (index >= colorIndex) {
           fprintf(stderr, "Cache error in chunk %ld %ld: %d/%d\n", xPos, zPos,

--- a/canvas.cpp
+++ b/canvas.cpp
@@ -94,8 +94,29 @@ void IsometricCanvas::drawTerrain(const Terrain::Data &world) {
 #ifdef CLOCK
   auto begin = std::chrono::high_resolution_clock::now();
 #endif
-  for (size_t xCanvasPos = 0; xCanvasPos < (sizeX >> 4) + 1; xCanvasPos++) {
-    for (size_t zCanvasPos = 0; zCanvasPos < (sizeZ >> 4) + 1; zCanvasPos++) {
+  // Those ugly ass values represent the exact number of chunks the map spans.
+  // The tough part is that depending on the coordinates, a section of the same
+  // size can cover a different number of chunks. (0x0 to 15x15 covers one
+  // chunk, -7x-7 to 8x8 covers 4)
+  //
+  // What I came up with is "aligning" the size by removing the length from the
+  // beginning to the first chunk boundary. That way, the length spans
+  // ceil(length) chunks, +1 if the min was on another chunk.
+  const uint64_t nXChunks =
+      ceil(float(sizeX -
+                 (map.minX % 16 > 0 ? 16 - map.minX % 16 : -map.minX % 16) +
+                 1) /
+           16) +
+      (map.minX % 16 ? 1 : 0);
+  const uint64_t nZChunks =
+      ceil(float(sizeZ -
+                 (map.minZ % 16 > 0 ? 16 - map.minZ % 16 : -map.minZ % 16) +
+                 1) /
+           16) +
+      (map.minZ % 16 ? 1 : 0);
+
+  for (size_t xCanvasPos = 0; xCanvasPos < nXChunks; xCanvasPos++) {
+    for (size_t zCanvasPos = 0; zCanvasPos < nZChunks; zCanvasPos++) {
       drawChunk(world, xCanvasPos, zCanvasPos);
     }
   }
@@ -148,6 +169,9 @@ void IsometricCanvas::drawSection(const NBT &section, const int64_t xPos,
   if (section.is_end() || !section.contains("Palette"))
     return;
 
+  int64_t worldChunkX = 0, worldChunkZ = 0;
+  translate(xPos, zPos, &worldChunkX, &worldChunkZ);
+
   uint16_t colorIndex = 0;
   Colors::Block *cache[256];
   Colors::Block fallback; // empty color to use in case no color is defined
@@ -165,12 +189,25 @@ void IsometricCanvas::drawSection(const NBT &section, const int64_t xPos,
     }
   }
 
+  // Get the min/max x index to render in the chunk, between 0 and 16.
+  const uint8_t minX =
+      (16 + (std::max(map.minX, int(worldChunkX << 4))) % 16) % 16;
+  const uint8_t maxX =
+      (16 + std::min(map.maxX, int(((worldChunkX + 1) << 4) - 1)) % 16) % 16;
+  const uint8_t offsetX = (16 + (map.minX % 16)) % 16;
+
+  const uint8_t minZ =
+      (16 + (std::max(map.minZ, int(worldChunkZ << 4))) % 16) % 16;
+  const uint8_t maxZ =
+      (16 + std::min(map.maxZ, int(((worldChunkZ + 1) << 4) - 1)) % 16) % 16;
+  const uint8_t offsetZ = (16 + (map.minZ % 16)) % 16;
+
   const uint8_t minY = (map.minY < (yPos << 4) ? 0 : map.minY - (yPos << 4));
   const uint8_t maxY =
       ((yPos + 1) << 4 > map.maxY ? map.maxY - (yPos << 4) + 1 : 16);
 
-  for (uint8_t x = 0; x < 16; x++) {
-    for (uint8_t z = 0; z < 16; z++) {
+  for (uint8_t x = minX; x < maxX + 1; x++) {
+    for (uint8_t z = minZ; z < maxZ + 1; z++) {
       for (uint8_t y = minY; y < maxY; y++) {
         int16_t index = interpreter(section, x, z, y);
 
@@ -180,9 +217,11 @@ void IsometricCanvas::drawSection(const NBT &section, const int64_t xPos,
           continue;
         }
 
-        if (index)
-          drawBlock(cache[index], (xPos << 4) + x, (zPos << 4) + z,
-                    (yPos << 4) + y, section["Palette"][index]);
+        if (index) {
+          drawBlock(cache[index], (xPos << 4) + x - offsetX,
+                    (zPos << 4) + z - offsetZ, (yPos << 4) + y,
+                    section["Palette"][index]);
+        }
       }
     }
   }

--- a/canvas.h
+++ b/canvas.h
@@ -45,26 +45,8 @@ struct IsometricCanvas {
     // that.
     this->padding = 2 + padding;
 
-    // Those ugly ass values represent the exact number of chunks the map spans.
-    // The tough part is that depending on the coordinates, a section of the
-    // same size can cover a different number of chunks. (0x0 to 15x15 covers
-    // one chunk, -7x-7 to 8x8 covers 4)
-    //
-    // What I came up with is "aligning" the size by removing the length from
-    // the beginning to the first chunk boundary. That way, the length spans
-    // ceil(length) chunks, +1 if the min was on another chunk.
-    nXChunks =
-        ceil(float(map.maxX - map.minX -
-                   (map.minX % 16 > 0 ? 16 - map.minX % 16 : -map.minX % 16) +
-                   1) /
-             16) +
-        (map.minX % 16 ? 1 : 0);
-    nZChunks =
-        ceil(float(map.maxZ - map.minZ -
-                   (map.minZ % 16 > 0 ? 16 - map.minZ % 16 : -map.minZ % 16) +
-                   1) /
-             16) +
-        (map.minZ % 16 ? 1 : 0);
+    nXChunks = CHUNK(map.maxX) - CHUNK(map.minX) + 1;
+    nZChunks = CHUNK(map.maxZ) - CHUNK(map.minZ) + 1;
 
     sizeX = nXChunks << 4;
     sizeZ = nZChunks << 4;

--- a/canvas.h
+++ b/canvas.h
@@ -94,8 +94,14 @@ struct IsometricCanvas {
 
   // Drawing entrypoints
   void drawTerrain(const Terrain::Data &);
+  void drawChunk(const Terrain::Data &, const int64_t, const int64_t);
+  void drawSection(const NBT &, const int64_t, const int64_t, const uint8_t,
+                   sectionInterpreter);
+  void drawChunk(const NBT &);
   void drawBlock(const size_t, const size_t, const NBT &);
   inline void drawBlock(const size_t, const size_t, const size_t, const NBT &);
+  void drawBlock(const Colors::Block *, const size_t, const size_t,
+                 const size_t, const NBT &);
 
   // This obscure typedef allows to create a member function pointer array
   // (ouch) to render different block types without a switch case

--- a/worldloader.h
+++ b/worldloader.h
@@ -75,7 +75,6 @@ struct Data {
                  const int chunkZ);
 
   // Chunk analysis methods - using the list of sections
-  void tagSections(vector<NBT> *);
   void stripChunk(vector<NBT> *);
   void cacheColors(vector<NBT> *);
   uint8_t importHeight(vector<NBT> *);
@@ -83,6 +82,10 @@ struct Data {
 
   size_t chunkIndex(int64_t x, int64_t z) const {
     return (x - map.minX) + (z - map.minZ) * (map.maxX - map.minX + 1);
+  }
+
+  const NBT &chunkAt(int64_t xPos, int64_t zPos) const {
+    return chunks[chunkIndex(xPos, zPos)];
   }
 
   uint8_t maxHeight() const { return heightBounds & 0xf0; }
@@ -96,9 +99,17 @@ struct Data {
     return (heightMap[chunkIndex(CHUNK(x), CHUNK(z))] & 0x0f) << 4;
   }
 
-  const NBT &block(const int32_t x, const int32_t z, const int32_t y) const;
+  uint8_t heightAt(int64_t xPos, int64_t zPos) const {
+    return heightMap[chunkIndex(xPos, zPos)];
+  }
 };
 
 } // namespace Terrain
+
+typedef int16_t (*sectionInterpreter)(const NBT &, uint8_t, uint8_t, uint8_t);
+
+int16_t blockAtEmpty(const NBT &, uint8_t, uint8_t, uint8_t);
+int16_t blockAtPre116(const NBT &, uint8_t, uint8_t, uint8_t);
+int16_t blockAtPost116(const NBT &, uint8_t, uint8_t, uint8_t);
 
 #endif // WORLDLOADER_H_

--- a/worldloader.h
+++ b/worldloader.h
@@ -106,10 +106,13 @@ struct Data {
 
 } // namespace Terrain
 
-typedef int16_t (*sectionInterpreter)(const NBT &, uint8_t, uint8_t, uint8_t);
+typedef int16_t (*sectionInterpreter)(const uint64_t,
+                                      const std::vector<int64_t> *, uint8_t,
+                                      uint8_t, uint8_t);
 
-int16_t blockAtEmpty(const NBT &, uint8_t, uint8_t, uint8_t);
-int16_t blockAtPre116(const NBT &, uint8_t, uint8_t, uint8_t);
-int16_t blockAtPost116(const NBT &, uint8_t, uint8_t, uint8_t);
+int16_t blockAtPre116(const uint64_t, const std::vector<int64_t> *, uint8_t,
+                      uint8_t, uint8_t);
+int16_t blockAtPost116(const uint64_t, const std::vector<int64_t> *, uint8_t,
+                       uint8_t, uint8_t);
 
 #endif // WORLDLOADER_H_


### PR DESCRIPTION
Rendering the world on a per-section basis allowed to reduce pricy access to some data to once per section, meaning a 4096 times decrease. This approach should have been done since the beginning, but the code is much more complex.

The changes greatly improve performance, with a 6x increase on my dev machine.
The program is even faster that the legacy version.