### PR TITLE
32bit support

### DIFF
--- a/src/canvas.cpp
+++ b/src/canvas.cpp
@@ -74,24 +74,27 @@ size_t IsometricCanvas::getCroppedOffset() const {
 // Translate a chunk in the canvas to a chunk in the world
 void IsometricCanvas::translate(size_t xCanvasPos, size_t zCanvasPos,
                                 int64_t *xPos, int64_t *zPos) {
+  // This is due to a converion error on ARM32
+  int64_t offsetX = int64_t(xCanvasPos), offsetZ = int64_t(zCanvasPos);
+
   switch (map.orientation) {
   case NW:
-    *xPos = (map.minX >> 4) + xCanvasPos;
-    *zPos = (map.minZ >> 4) + zCanvasPos;
+    *xPos = (map.minX >> 4) + offsetX;
+    *zPos = (map.minZ >> 4) + offsetZ;
     break;
   case SW:
-    std::swap(xCanvasPos, zCanvasPos);
-    *xPos = (map.minX >> 4) + xCanvasPos;
-    *zPos = (map.maxZ >> 4) - zCanvasPos;
+    std::swap(offsetX, offsetZ);
+    *xPos = (map.minX >> 4) + offsetX;
+    *zPos = (map.maxZ >> 4) - offsetZ;
     break;
   case NE:
-    std::swap(xCanvasPos, zCanvasPos);
-    *xPos = (map.maxX >> 4) - xCanvasPos;
-    *zPos = (map.minZ >> 4) + zCanvasPos;
+    std::swap(offsetX, offsetZ);
+    *xPos = (map.maxX >> 4) - offsetX;
+    *zPos = (map.minZ >> 4) + offsetZ;
     break;
   case SE:
-    *xPos = (map.maxX >> 4) - xCanvasPos;
-    *zPos = (map.maxZ >> 4) - zCanvasPos;
+    *xPos = (map.maxX >> 4) - offsetX;
+    *zPos = (map.maxZ >> 4) - offsetZ;
     break;
   }
 }

--- a/src/canvas.cpp
+++ b/src/canvas.cpp
@@ -235,8 +235,8 @@ void IsometricCanvas::drawSection(const NBT &section, const int64_t xPos,
       section["BlockStates"].get<const std::vector<int64_t> *>();
 
   // This will be used by the section interpreter later
-  const uint64_t blockBitLength =
-      std::max(uint64_t(ceil(log2(sectionPalette->size()))), 4ul);
+  const uint32_t blockBitLength =
+      std::max(uint32_t(ceil(log2(sectionPalette->size()))), uint32_t(4));
 
   // We need the real position of the section for bounds checking
   translate(xPos, zPos, &worldChunkX, &worldChunkZ);

--- a/src/canvas.cpp
+++ b/src/canvas.cpp
@@ -16,48 +16,49 @@ NBT empty;
 //                |_|   |_|            |___/
 // The following methods are related to the cropping mechanism.
 
-size_t IsometricCanvas::getCroppedWidth() const {
+uint32_t IsometricCanvas::getCroppedWidth() const {
   // Not implemented, returns the actual width. Might come back to this but it
   // is not as interesting as the height.
   return width;
 }
 
-size_t IsometricCanvas::firstLine() const {
+uint32_t IsometricCanvas::firstLine() const {
   // Tip: Return -7 for a freaky glichy look
   // return -7;
 
-  // We search for the first non-empty line
-  size_t line = 0;
+  // We search for the first non-empty line, return it as a line index (ie line
+  // n)
+  uint32_t line = 0;
 
-  for (size_t row = 0; row < height && !line; row++)
-    for (size_t pixel = 0; pixel < width && !line; pixel++)
+  for (uint32_t row = 0; row < height && !line; row++)
+    for (uint32_t pixel = 0; pixel < width && !line; pixel++)
       if (*(bytesBuffer + (pixel + row * width) * BYTESPERPIXEL))
         line = row;
 
   return line - (padding - 2);
 }
 
-size_t IsometricCanvas::lastLine() const {
+uint32_t IsometricCanvas::lastLine() const {
   // We search for the last non-empty line
-  size_t line = 0;
+  uint32_t line = 0;
 
-  for (size_t row = height - 1; row > 0 && !line; row--)
-    for (size_t pixel = 0; pixel < width && !line; pixel++)
+  for (uint32_t row = height - 1; row > 0 && !line; row--)
+    for (uint32_t pixel = 0; pixel < width && !line; pixel++)
       if (*(bytesBuffer + (pixel + row * width) * BYTESPERPIXEL))
         line = row;
 
   return line + (padding - 2);
 }
 
-size_t IsometricCanvas::getCroppedHeight() const {
-  size_t croppedHeight = lastLine() - firstLine();
+uint32_t IsometricCanvas::getCroppedHeight() const {
+  uint32_t croppedHeight = lastLine() - firstLine();
   if (croppedHeight == (padding - 2) * 2)
     return 0;
   else
     return croppedHeight + 1;
 }
 
-size_t IsometricCanvas::getCroppedOffset() const {
+uint64_t IsometricCanvas::getCroppedOffset() const {
   // The first line to render in the cropped view of the canvas, as an offset
   // from the beginning of the byte buffer
   return firstLine() * width * BYTESPERPIXEL;
@@ -72,39 +73,41 @@ size_t IsometricCanvas::getCroppedOffset() const {
 // The following methods are used to draw the map into the canvas' 2D buffer
 
 // Translate a chunk in the canvas to a chunk in the world
-void IsometricCanvas::translate(size_t xCanvasPos, size_t zCanvasPos,
-                                int64_t *xPos, int64_t *zPos) {
+void IsometricCanvas::orientChunk(uint32_t canvasX, uint32_t canvasZ,
+                                  int64_t *worldX, int64_t *worldZ) {
   // This is due to a converion error on ARM32
-  int64_t offsetX = int64_t(xCanvasPos), offsetZ = int64_t(zCanvasPos);
+  int64_t offsetX = int64_t(canvasX), offsetZ = int64_t(canvasZ);
 
   switch (map.orientation) {
   case NW:
-    *xPos = (map.minX >> 4) + offsetX;
-    *zPos = (map.minZ >> 4) + offsetZ;
+    *worldX = (map.minX >> 4) + offsetX;
+    *worldZ = (map.minZ >> 4) + offsetZ;
     break;
   case SW:
     std::swap(offsetX, offsetZ);
-    *xPos = (map.minX >> 4) + offsetX;
-    *zPos = (map.maxZ >> 4) - offsetZ;
+    *worldX = (map.minX >> 4) + offsetX;
+    *worldZ = (map.maxZ >> 4) - offsetZ;
     break;
   case NE:
     std::swap(offsetX, offsetZ);
-    *xPos = (map.maxX >> 4) - offsetX;
-    *zPos = (map.minZ >> 4) + offsetZ;
+    *worldX = (map.maxX >> 4) - offsetX;
+    *worldZ = (map.minZ >> 4) + offsetZ;
     break;
   case SE:
-    *xPos = (map.maxX >> 4) - offsetX;
-    *zPos = (map.maxZ >> 4) - offsetZ;
+    *worldX = (map.maxX >> 4) - offsetX;
+    *worldZ = (map.maxZ >> 4) - offsetZ;
     break;
   }
 }
 
-void IsometricCanvas::drawTerrain(const Terrain::Data &world) {
-  for (size_t xCanvasPos = 0; xCanvasPos < nXChunks; xCanvasPos++) {
-    for (size_t zCanvasPos = 0; zCanvasPos < nZChunks; zCanvasPos++) {
-      drawChunk(world, xCanvasPos, zCanvasPos);
-      logger::printProgress("Rendering chunks",
-                            xCanvasPos * nZChunks + zCanvasPos,
+void IsometricCanvas::renderTerrain(const Terrain::Data &world) {
+  // world is supposed to have the SAME set of coordinates as the canvas
+  uint32_t chunkX, chunkZ;
+
+  for (chunkX = 0; chunkX < nXChunks; chunkX++) {
+    for (chunkZ = 0; chunkZ < nZChunks; chunkZ++) {
+      renderChunk(world, chunkX, chunkZ);
+      logger::printProgress("Rendering chunks", chunkX * nZChunks + chunkZ,
                             nZChunks * nXChunks);
     }
   }
@@ -112,13 +115,14 @@ void IsometricCanvas::drawTerrain(const Terrain::Data &world) {
   return;
 }
 
-void IsometricCanvas::drawChunk(const Terrain::Data &terrain,
-                                const int64_t xPos, const int64_t zPos) {
-  int64_t worldChunkX = 0, worldChunkZ = 0;
-  translate(xPos, zPos, &worldChunkX, &worldChunkZ);
+void IsometricCanvas::renderChunk(const Terrain::Data &terrain,
+                                  const int64_t canvasX,
+                                  const int64_t canvasZ) {
+  int64_t worldX = 0, worldZ = 0;
+  orientChunk(canvasX, canvasZ, &worldX, &worldZ);
 
-  const NBT &chunk = terrain.chunkAt(worldChunkX, worldChunkZ);
-  const uint8_t height = terrain.heightAt(worldChunkX, worldChunkZ);
+  const NBT &chunk = terrain.chunkAt(worldX, worldZ);
+  const uint8_t height = terrain.heightAt(worldX, worldZ);
 
   if (chunk.is_end()                          // Catch uninitialized chunks
       || !chunk.contains("DataVersion")       // Dataversion is required
@@ -145,8 +149,7 @@ void IsometricCanvas::drawChunk(const Terrain::Data &terrain,
   // Setup the markers
   localMarkers = 0;
   for (uint8_t i = 0; i < totalMarkers; i++) {
-    if (CHUNK((*markers)[i].x) == worldChunkX &&
-        CHUNK((*markers)[i].z) == worldChunkZ) {
+    if (CHUNK((*markers)[i].x) == worldX && CHUNK((*markers)[i].z) == worldZ) {
       chunkMarkers[localMarkers++] =
           (i << 8) + (((*markers)[i].x & 0x0f) << 4) + ((*markers)[i].z & 0x0f);
     }
@@ -156,18 +159,18 @@ void IsometricCanvas::drawChunk(const Terrain::Data &terrain,
   const uint8_t maxSection = std::min((map.maxY >> 4) + 1, (height >> 4));
 
   for (uint8_t yPos = minSection; yPos < maxSection; yPos++) {
-    drawSection(chunk["Level"]["Sections"][yPos], xPos, zPos, yPos,
-                interpreter);
+    renderSection(chunk["Level"]["Sections"][yPos], canvasX, canvasZ, yPos,
+                  interpreter);
   }
 
   if (numBeacons || localMarkers)
     for (uint8_t yPos = maxSection; yPos < 13; yPos++)
-      drawBeams(xPos, zPos, yPos);
+      renderBeamSection(canvasX, canvasZ, yPos);
 }
 
 // Section version of translate above
-inline void orient(uint8_t &x, uint8_t &z, Orientation o) {
-  switch (o) {
+inline void IsometricCanvas::orientSection(uint8_t &x, uint8_t &z) {
+  switch (map.orientation) {
   case NW:
     return;
   case NE:
@@ -185,34 +188,9 @@ inline void orient(uint8_t &x, uint8_t &z, Orientation o) {
   }
 }
 
-void IsometricCanvas::drawBeams(const int64_t xPos, const int64_t zPos,
-                                const uint8_t yPos) {
-  // Draw beacon beams in an empty section
-  uint8_t x, z, index;
-
-  for (uint8_t beam = 0; beam < numBeacons; beam++) {
-    x = beacons[beam] >> 4;
-    z = beacons[beam] & 0x0f;
-
-    for (uint8_t y = 0; y < 16; y++)
-      drawBlock(&beaconBeam, (xPos << 4) + x, (zPos << 4) + z, (yPos << 4) + y,
-                empty);
-  }
-
-  for (uint8_t marker = 0; marker < localMarkers; marker++) {
-    x = (chunkMarkers[marker] >> 4) & 0x0f;
-    z = chunkMarkers[marker] & 0x0f;
-    index = chunkMarkers[marker] >> 8;
-
-    for (uint8_t y = 0; y < 16; y++)
-      drawBlock(&(*markers)[index].color, (xPos << 4) + x, (zPos << 4) + z,
-                (yPos << 4) + y, empty);
-  }
-}
-
-void IsometricCanvas::drawSection(const NBT &section, const int64_t xPos,
-                                  const int64_t zPos, const uint8_t yPos,
-                                  sectionInterpreter interpreter) {
+void IsometricCanvas::renderSection(const NBT &section, const int64_t xPos,
+                                    const int64_t zPos, const uint8_t yPos,
+                                    sectionInterpreter interpreter) {
   // TODO Take care of this case in the chunk drawing
   if (!interpreter) {
     logger::error("Invalid section interpreter\n");
@@ -242,7 +220,7 @@ void IsometricCanvas::drawSection(const NBT &section, const int64_t xPos,
       std::max(uint32_t(ceil(log2(sectionPalette->size()))), uint32_t(4));
 
   // We need the real position of the section for bounds checking
-  translate(xPos, zPos, &worldChunkX, &worldChunkZ);
+  orientChunk(xPos, zPos, &worldChunkX, &worldChunkZ);
 
   // Preload the colors in the order they appear in the palette into an array
   // for cheaper access
@@ -265,7 +243,7 @@ void IsometricCanvas::drawSection(const NBT &section, const int64_t xPos,
     for (uint8_t z = 0; z < 16; z++) {
       // Orient the indexes for them to correspond to the orientation
       uint8_t xReal = x, zReal = z;
-      orient(xReal, zReal, map.orientation);
+      orientSection(xReal, zReal);
 
       // If we are oob, skip the line
       if ((worldChunkX << 4) + xReal > map.maxX ||
@@ -287,12 +265,12 @@ void IsometricCanvas::drawSection(const NBT &section, const int64_t xPos,
       for (uint8_t y = 0; y < 16; y++) {
         // Render the beams, even if we are oob
         if (beaconBeamColumn)
-          drawBlock(&beaconBeam, (xPos << 4) + x, (zPos << 4) + z,
-                    (yPos << 4) + y, empty);
+          renderBlock(&beaconBeam, (xPos << 4) + x, (zPos << 4) + z,
+                      (yPos << 4) + y, empty);
 
         if (markerColumn)
-          drawBlock(&(*markers)[markerIndex].color, (xPos << 4) + x,
-                    (zPos << 4) + z, (yPos << 4) + y, empty);
+          renderBlock(&(*markers)[markerIndex].color, (xPos << 4) + x,
+                      (zPos << 4) + z, (yPos << 4) + y, empty);
 
         // Check that we do not step over the height limit
         if ((yPos << 4) + y < map.minY || (yPos << 4) + y > map.maxY)
@@ -311,8 +289,8 @@ void IsometricCanvas::drawSection(const NBT &section, const int64_t xPos,
 
         // Skip air. This does increase performance, but could be tweaked.
         if (index)
-          drawBlock(cache[index], (xPos << 4) + x, (zPos << 4) + z,
-                    (yPos << 4) + y, sectionPalette->operator[](index));
+          renderBlock(cache[index], (xPos << 4) + x, (zPos << 4) + z,
+                      (yPos << 4) + y, sectionPalette->operator[](index));
 
         // A beam can begin at every moment in a section
         if (index == beaconIndex) {
@@ -327,6 +305,31 @@ void IsometricCanvas::drawSection(const NBT &section, const int64_t xPos,
   }
 
   return;
+}
+
+void IsometricCanvas::renderBeamSection(const int64_t xPos, const int64_t zPos,
+                                        const uint8_t yPos) {
+  // Draw beacon beams in an empty section
+  uint8_t x, z, index;
+
+  for (uint8_t beam = 0; beam < numBeacons; beam++) {
+    x = beacons[beam] >> 4;
+    z = beacons[beam] & 0x0f;
+
+    for (uint8_t y = 0; y < 16; y++)
+      renderBlock(&beaconBeam, (xPos << 4) + x, (zPos << 4) + z,
+                  (yPos << 4) + y, empty);
+  }
+
+  for (uint8_t marker = 0; marker < localMarkers; marker++) {
+    x = (chunkMarkers[marker] >> 4) & 0x0f;
+    z = chunkMarkers[marker] & 0x0f;
+    index = chunkMarkers[marker] >> 8;
+
+    for (uint8_t y = 0; y < 16; y++)
+      renderBlock(&(*markers)[index].color, (xPos << 4) + x, (zPos << 4) + z,
+                  (yPos << 4) + y, empty);
+  }
 }
 
 // ____  _            _
@@ -344,12 +347,12 @@ IsometricCanvas::drawer blockRenderers[] = {
 #undef DEFINETYPE
 };
 
-inline void IsometricCanvas::drawBlock(Colors::Block *color, const size_t x,
-                                       const size_t z, const size_t y,
-                                       const NBT &metadata) {
-  const size_t bmpPosX = 2 * (sizeZ - 1) + (x - z) * 2 + padding;
-  const size_t bmpPosY = height - 2 + x + z - sizeX - sizeZ -
-                         (y - map.minY) * heightOffset - padding;
+inline void IsometricCanvas::renderBlock(Colors::Block *color, const uint32_t x,
+                                         const uint32_t z, const uint32_t y,
+                                         const NBT &metadata) {
+  const uint32_t bmpPosX = 2 * (sizeZ - 1) + (x - z) * 2 + padding;
+  const uint32_t bmpPosY = height - 2 + x + z - sizeX - sizeZ -
+                           (y - map.minY) * heightOffset - padding;
 
   if (bmpPosX > width - 1)
     throw std::range_error("Invalid x: " + std::to_string(bmpPosX) + "/" +
@@ -412,7 +415,7 @@ inline void addColor(uint8_t *const color, const uint8_t *const add) {
   color[2] = clamp(uint16_t(float(color[2]) * v1 + float(add[2]) * v2));
 }
 
-void IsometricCanvas::drawHead(const size_t x, const size_t y, const NBT &,
+void IsometricCanvas::drawHead(const uint32_t x, const uint32_t y, const NBT &,
                                const Colors::Block *block) {
   /* Small block centered
    * |    |
@@ -428,7 +431,7 @@ void IsometricCanvas::drawHead(const size_t x, const size_t y, const NBT &,
   memcpy(pos + CHANSPERPIXEL, &block->light, BYTESPERPIXEL);
 }
 
-void IsometricCanvas::drawThin(const size_t x, const size_t y, const NBT &,
+void IsometricCanvas::drawThin(const uint32_t x, const uint32_t y, const NBT &,
                                const Colors::Block *block) {
   /* Overwrite the block below's top layer
    * |    |
@@ -437,20 +440,19 @@ void IsometricCanvas::drawThin(const size_t x, const size_t y, const NBT &,
    * |XXXX|
    *   XX   */
   uint8_t *pos = pixel(x, y + 3);
-  for (size_t i = 0; i < 4; ++i, pos += CHANSPERPIXEL) {
+  for (uint8_t i = 0; i < 4; ++i, pos += CHANSPERPIXEL)
     memcpy(pos, &block->primary, BYTESPERPIXEL);
-  }
   pos = pixel(x + 1, y + 4);
   memcpy(pos, &block->dark, BYTESPERPIXEL);
   memcpy(pos + CHANSPERPIXEL, &block->light, BYTESPERPIXEL);
 }
 
-void IsometricCanvas::drawHidden(const size_t, const size_t, const NBT &,
+void IsometricCanvas::drawHidden(const uint32_t, const uint32_t, const NBT &,
                                  const Colors::Block *) {
   return;
 }
 
-void IsometricCanvas::drawTransparent(const size_t x, const size_t y,
+void IsometricCanvas::drawTransparent(const uint32_t x, const uint32_t y,
                                       const NBT &, const Colors::Block *block) {
   // Avoid the top and dark/light edges for a clearer look through
   uint8_t *pos = pixel(x, y + 1);
@@ -460,7 +462,7 @@ void IsometricCanvas::drawTransparent(const size_t x, const size_t y,
   }
 }
 
-void IsometricCanvas::drawTorch(const size_t x, const size_t y, const NBT &,
+void IsometricCanvas::drawTorch(const uint32_t x, const uint32_t y, const NBT &,
                                 const Colors::Block *block) {
   /* TODO Callback to handle the orientation
    * Print the secondary on top of two primary
@@ -473,7 +475,7 @@ void IsometricCanvas::drawTorch(const size_t x, const size_t y, const NBT &,
   memcpy(pixel(x + 2, y + 3), &block->primary, BYTESPERPIXEL);
 }
 
-void IsometricCanvas::drawPlant(const size_t x, const size_t y, const NBT &,
+void IsometricCanvas::drawPlant(const uint32_t x, const uint32_t y, const NBT &,
                                 const Colors::Block *block) {
   /* Print a plant-like block
    * TODO Make that nicer ?
@@ -489,7 +491,7 @@ void IsometricCanvas::drawPlant(const size_t x, const size_t y, const NBT &,
   memcpy(pixel(x + 1, y + 3), &block->primary, BYTESPERPIXEL);
 }
 
-void IsometricCanvas::drawUnderwaterPlant(const size_t x, const size_t y,
+void IsometricCanvas::drawUnderwaterPlant(const uint32_t x, const uint32_t y,
                                           const NBT &,
                                           const Colors::Block *block) {
   /* Print a plant-like block
@@ -502,7 +504,7 @@ void IsometricCanvas::drawUnderwaterPlant(const size_t x, const size_t y,
   drawTransparent(x, y, empty, &water);
 }
 
-void IsometricCanvas::drawFire(const size_t x, const size_t y, const NBT &,
+void IsometricCanvas::drawFire(const uint32_t x, const uint32_t y, const NBT &,
                                const Colors::Block *const color) {
   // This basically just leaves out a few pixels
   // Top row
@@ -510,7 +512,7 @@ void IsometricCanvas::drawFire(const size_t x, const size_t y, const NBT &,
   blend(pos, (uint8_t *)&color->light);
   blend(pos + CHANSPERPIXEL * 2, (uint8_t *)&color->dark);
   // Second and third row
-  for (size_t i = 1; i < 3; ++i) {
+  for (uint8_t i = 1; i < 3; ++i) {
     pos = pixel(x, y + i);
     blend(pos, (uint8_t *)&color->dark);
     blend(pos + (CHANSPERPIXEL * i), (uint8_t *)&color->primary);
@@ -521,7 +523,7 @@ void IsometricCanvas::drawFire(const size_t x, const size_t y, const NBT &,
   blend(pos + (CHANSPERPIXEL * 2), (uint8_t *)&color->light);
 }
 
-void IsometricCanvas::drawOre(const size_t x, const size_t y, const NBT &,
+void IsometricCanvas::drawOre(const uint32_t x, const uint32_t y, const NBT &,
                               const Colors::Block *color) {
   /* Print a vein with the secondary in the block
    * |PSPP|
@@ -543,12 +545,12 @@ void IsometricCanvas::drawOre(const size_t x, const size_t y, const NBT &,
       {&secondaryDark, &color->dark, &color->light, &color->light}};
 
   uint8_t *pos = pixel(x, y);
-  for (size_t j = 0; j < 4; ++j, pos = pixel(x, y + j))
-    for (size_t i = 0; i < 4; ++i, pos += CHANSPERPIXEL)
+  for (uint8_t j = 0; j < 4; ++j, pos = pixel(x, y + j))
+    for (uint8_t i = 0; i < 4; ++i, pos += CHANSPERPIXEL)
       memcpy(pos, sprite[j][i], BYTESPERPIXEL);
 }
 
-void IsometricCanvas::drawGrown(const size_t x, const size_t y, const NBT &,
+void IsometricCanvas::drawGrown(const uint32_t x, const uint32_t y, const NBT &,
                                 const Colors::Block *color) {
   /* Print the secondary color on top
    * |SSSS|
@@ -573,12 +575,12 @@ void IsometricCanvas::drawGrown(const size_t x, const size_t y, const NBT &,
       {&color->dark, &color->dark, &color->light, &color->light}};
 
   uint8_t *pos = pixel(x, y);
-  for (size_t j = 0; j < 4; ++j, pos = pixel(x, y + j))
-    for (size_t i = 0; i < 4; ++i, pos += CHANSPERPIXEL)
+  for (uint8_t j = 0; j < 4; ++j, pos = pixel(x, y + j))
+    for (uint8_t i = 0; i < 4; ++i, pos += CHANSPERPIXEL)
       memcpy(pos, sprite[j][i], BYTESPERPIXEL);
 }
 
-void IsometricCanvas::drawRod(const size_t x, const size_t y, const NBT &,
+void IsometricCanvas::drawRod(const uint32_t x, const uint32_t y, const NBT &,
                               const Colors::Block *const color) {
   /* A full fat rod
    * | PP |
@@ -590,13 +592,13 @@ void IsometricCanvas::drawRod(const size_t x, const size_t y, const NBT &,
   memcpy(pos + CHANSPERPIXEL, &color->primary, BYTESPERPIXEL);
 
   pos = pixel(x + 1, y + 1);
-  for (int i = 1; i < 4; i++, pos = pixel(x + 1, y + i)) {
+  for (uint8_t i = 1; i < 4; i++, pos = pixel(x + 1, y + i)) {
     memcpy(pos, &color->dark, BYTESPERPIXEL);
     memcpy(pos + CHANSPERPIXEL, &color->light, BYTESPERPIXEL);
   }
 }
 
-void IsometricCanvas::drawBeam(const size_t x, const size_t y, const NBT &,
+void IsometricCanvas::drawBeam(const uint32_t x, const uint32_t y, const NBT &,
                                const Colors::Block *const color) {
   /* No top to make it look more continuous
    * |    |
@@ -604,13 +606,13 @@ void IsometricCanvas::drawBeam(const size_t x, const size_t y, const NBT &,
    * | DL |
    * | DL | */
   uint8_t *pos = pixel(x + 1, y + 1);
-  for (int i = 1; i < 4; i++, pos = pixel(x + 1, y + i)) {
+  for (uint8_t i = 1; i < 4; i++, pos = pixel(x + 1, y + i)) {
     blend(pos, (uint8_t *)&color->dark);
     blend(pos + CHANSPERPIXEL, (uint8_t *)&color->light);
   }
 }
 
-void IsometricCanvas::drawSlab(const size_t x, const size_t y,
+void IsometricCanvas::drawSlab(const uint32_t x, const uint32_t y,
                                const NBT &metadata,
                                const Colors::Block *color) {
   /* This one has a hack to make it look like a gradual step up:
@@ -653,32 +655,19 @@ void IsometricCanvas::drawSlab(const size_t x, const size_t y,
   }
 
   uint8_t *pos = pixel(x, y + (top ? 0 : 1));
-  for (size_t j = 0; j < 3; ++j, pos = pixel(x, y + j + (top ? 0 : 1)))
-    for (size_t i = 0; i < 4; ++i, pos += CHANSPERPIXEL)
+  for (uint8_t j = 0; j < 3; ++j, pos = pixel(x, y + j + (top ? 0 : 1)))
+    for (uint8_t i = 0; i < 4; ++i, pos += CHANSPERPIXEL)
       memcpy(pos, (*target)[j][i], BYTESPERPIXEL);
 }
 
-void IsometricCanvas::drawWire(const size_t x, const size_t y, const NBT &,
+void IsometricCanvas::drawWire(const uint32_t x, const uint32_t y, const NBT &,
                                const Colors::Block *color) {
   uint8_t *pos = pixel(x + 1, y + 3);
   memcpy(pos, &color->primary, BYTESPERPIXEL);
   memcpy(pos + CHANSPERPIXEL, &color->primary, BYTESPERPIXEL);
 }
 
-/*
-        void setUpStep(const size_t x, const size_t y, const uint8_t *
-   const color, const uint8_t * const light, const uint8_t * const dark) {
-   uint8_t *pos = pixel(x, y); for (size_t i = 0; i < 4; ++i, pos +=
-   CHANSPERPIXEL) { memcpy(pos, color, BYTESPERPIXEL);
-                }
-                pos = pixel(x, y+1);
-                for (size_t i = 0; i < 4; ++i, pos += CHANSPERPIXEL) {
-                        memcpy(pos, color, BYTESPERPIXEL);
-                }
-        }
-*/
-
-void IsometricCanvas::drawLog(const size_t x, const size_t y,
+void IsometricCanvas::drawLog(const uint32_t x, const uint32_t y,
                               const NBT &metadata, const Colors::Block *color) {
 
   string axis = "y";
@@ -728,12 +717,12 @@ void IsometricCanvas::drawLog(const size_t x, const size_t y,
   }
 
   uint8_t *pos = pixel(x, y);
-  for (size_t j = 0; j < 4; ++j, pos = pixel(x, y + j))
-    for (size_t i = 0; i < 4; ++i, pos += CHANSPERPIXEL)
+  for (uint8_t j = 0; j < 4; ++j, pos = pixel(x, y + j))
+    for (uint8_t i = 0; i < 4; ++i, pos += CHANSPERPIXEL)
       memcpy(pos, (*target)[j][i], BYTESPERPIXEL);
 }
 
-void IsometricCanvas::drawFull(const size_t x, const size_t y, const NBT &,
+void IsometricCanvas::drawFull(const uint32_t x, const uint32_t y, const NBT &,
                                const Colors::Block *color) {
   // Sets pixels around x,y where A is the anchor
   // T = given color, D = darker, L = lighter
@@ -752,12 +741,12 @@ void IsometricCanvas::drawFull(const size_t x, const size_t y, const NBT &,
   uint8_t *pos = pixel(x, y);
 
   if (color->primary.ALPHA == 255) {
-    for (size_t j = 0; j < 4; ++j, pos = pixel(x, y + j))
-      for (size_t i = 0; i < 4; ++i, pos += CHANSPERPIXEL)
+    for (uint8_t j = 0; j < 4; ++j, pos = pixel(x, y + j))
+      for (uint8_t i = 0; i < 4; ++i, pos += CHANSPERPIXEL)
         memcpy(pos, sprite[j][i], BYTESPERPIXEL);
   } else {
-    for (size_t j = 0; j < 4; ++j, pos = pixel(x, y + j))
-      for (size_t i = 0; i < 4; ++i, pos += CHANSPERPIXEL)
+    for (uint8_t j = 0; j < 4; ++j, pos = pixel(x, y + j))
+      for (uint8_t i = 0; i < 4; ++i, pos += CHANSPERPIXEL)
         blend(pos, (uint8_t *)sprite[j][i]);
   }
 }
@@ -770,14 +759,14 @@ void IsometricCanvas::drawFull(const size_t x, const size_t y, const NBT &,
 //                 |___/         |___/
 // This is the canvas merging code.
 
-size_t IsometricCanvas::calcAnchor(const IsometricCanvas &subCanvas) {
+uint64_t IsometricCanvas::calcAnchor(const IsometricCanvas &subCanvas) {
   // Determine where in the canvas' 2D matrix is the subcanvas supposed to
   // go: the anchor is the bottom left pixel in the canvas where the
   // sub-canvas must be superimposed
-  size_t anchorX = 0, anchorY = height;
-  const size_t minOffset =
+  uint32_t anchorX = 0, anchorY = height;
+  const uint64_t minOffset =
       subCanvas.map.minX - map.minX + subCanvas.map.minZ - map.minZ;
-  const size_t maxOffset =
+  const uint64_t maxOffset =
       map.maxX - subCanvas.map.maxX + map.maxZ - subCanvas.map.maxZ;
 
   switch (map.orientation) {
@@ -814,10 +803,10 @@ size_t IsometricCanvas::calcAnchor(const IsometricCanvas &subCanvas) {
   return (anchorX + width * anchorY) * BYTESPERPIXEL;
 }
 
-void overLay(uint8_t *const dest, const uint8_t *const source,
-             const size_t width) {
+void overlay(uint8_t *const dest, const uint8_t *const source,
+             const uint32_t width) {
   // Render a sub-canvas above the canvas' content
-  for (size_t pixel = 0; pixel < width; pixel++) {
+  for (uint32_t pixel = 0; pixel < width; pixel++) {
     const uint8_t *data = source + pixel * BYTESPERPIXEL;
     // If the subCanvas is empty here, skip
     if (!data[3])
@@ -835,12 +824,12 @@ void overLay(uint8_t *const dest, const uint8_t *const source,
   }
 }
 
-void underLay(uint8_t *const dest, const uint8_t *const source,
-              const size_t width) {
+void underlay(uint8_t *const dest, const uint8_t *const source,
+              const uint32_t width) {
   // Render a sub-canvas under the canvas' content
   uint8_t tmpPixel[4];
 
-  for (size_t pixel = 0; pixel < width; pixel++) {
+  for (uint32_t pixel = 0; pixel < width; pixel++) {
     const uint8_t *data = source + pixel * BYTESPERPIXEL;
     // If the subCanvas is empty here, or the canvas already has a pixel
     if (!data[3] || (dest + pixel * BYTESPERPIXEL)[3] == 0xff)
@@ -863,7 +852,8 @@ void IsometricCanvas::merge(const IsometricCanvas &subCanvas) {
   // main canvas.
   //
   // This routine is supposed to be called multiple times with ORDERED
-  // subcanvasses
+  // subcanvasses (leftmost/rightmost first, then the one next to it, then ..
+  // etc. Easy as slices are made in only one direction)
   if (subCanvas.width > width || subCanvas.height > height) {
     logger::error("Cannot merge a canvas of bigger dimensions\n");
     return;
@@ -873,11 +863,11 @@ void IsometricCanvas::merge(const IsometricCanvas &subCanvas) {
   // go: the anchor is the bottom left pixel in the canvas where the
   // sub-canvas must be superimposed, translated as an offset from the
   // beginning of the buffer
-  const size_t anchor = calcAnchor(subCanvas);
+  const uint64_t anchor = calcAnchor(subCanvas);
 
   // For every line of the subCanvas, we create a pointer to its
   // beginning, and a pointer to where in the canvas it should be copied
-  for (size_t line = 1; line < subCanvas.height + 1; line++) {
+  for (uint32_t line = 1; line < subCanvas.height + 1; line++) {
     uint8_t *subLine = subCanvas.bytesBuffer + subCanvas.size -
                        line * subCanvas.width * BYTESPERPIXEL;
     uint8_t *position = bytesBuffer + anchor - line * width * BYTESPERPIXEL;
@@ -885,9 +875,9 @@ void IsometricCanvas::merge(const IsometricCanvas &subCanvas) {
     // Then import the line over or under the existing data, depending on
     // the orientation
     if (map.orientation == NW || map.orientation == SW)
-      overLay(position, subLine, subCanvas.width);
+      overlay(position, subLine, subCanvas.width);
     else
-      underLay(position, subLine, subCanvas.width);
+      underlay(position, subLine, subCanvas.width);
   }
 
 #ifdef CLOCK

--- a/src/canvas.h
+++ b/src/canvas.h
@@ -20,7 +20,7 @@ struct IsometricCanvas {
   size_t sizeX, sizeZ; // The size of the 3D map
 
   size_t width, height; // Bitmap width and height
-  size_t padding;       // Padding inside the image
+  uint16_t padding;     // Padding inside the image
   uint8_t heightOffset; // Offset for block rendering
 
   uint8_t *bytesBuffer; // The buffer where pixels are written
@@ -43,7 +43,7 @@ struct IsometricCanvas {
   float *brightnessLookup;
 
   IsometricCanvas(const Terrain::Coordinates &coords,
-                  const Colors::Palette &colors, const size_t padding = 0)
+                  const Colors::Palette &colors, const uint16_t padding = 0)
       : map(coords) {
     // This is a legacy setting, changing how the map is drawn. It can be 2 or
     // 3; it means that a block is drawn with a 2 or 3 pixel offset over the

--- a/src/canvas.h
+++ b/src/canvas.h
@@ -138,8 +138,7 @@ struct IsometricCanvas {
 
   // Drawing methods
   // Helpers for position lookup
-  void orientChunk(uint32_t canvasX, uint32_t canvasZ, int64_t *realX,
-                   int64_t *realZ);
+  void orientChunk(int32_t &x, int32_t &z);
   void orientSection(uint8_t &x, uint8_t &z);
   inline uint8_t *pixel(uint32_t x, uint32_t y) {
     return &bytesBuffer[(x + y * width) * BYTESPERPIXEL];

--- a/src/colors.h
+++ b/src/colors.h
@@ -137,7 +137,7 @@ struct Marker {
     z = std::numeric_limits<int64_t>::max();
   }
 
-  Marker(size_t x, size_t z, string c) : x(x), z(z), color_name(c) {
+  Marker(int64_t x, int64_t z, string c) : x(x), z(z), color_name(c) {
     auto marker = markerColors.find(color_name);
     if (marker == markerColors.end()) {
       fprintf(stderr, "Invalid marker color: %s\n", color_name.c_str());

--- a/src/draw_png.cpp
+++ b/src/draw_png.cpp
@@ -87,10 +87,10 @@ bool PNG::Image::save() {
   }
 
   uint8_t *srcLine = canvas->bytesBuffer + canvas->getCroppedOffset();
-  const size_t croppedHeight = canvas->getCroppedHeight();
+  const uint64_t croppedHeight = canvas->getCroppedHeight();
 
   logger::info("Writing to file...\n");
-  for (size_t y = 0; y < croppedHeight; ++y) {
+  for (uint64_t y = 0; y < croppedHeight; ++y) {
     png_write_row(pngPtr, (png_bytep)srcLine);
     srcLine += canvas->width * BYTESPERPIXEL;
   }

--- a/src/helper.cpp
+++ b/src/helper.cpp
@@ -38,10 +38,10 @@ bool isNumeric(char *str) {
 }
 
 void splitCoords(const Coordinates &original, Coordinates *&subCoords,
-                 const size_t count) {
+                 const uint16_t count) {
   // Split the coordinates of the entire terrain in `count` terrain fragments
 
-  for (size_t index = 0; index < count; index++) {
+  for (uint16_t index = 0; index < count; index++) {
     // Initialization with the original's values
     subCoords[index] = Coordinates(original);
 

--- a/src/helper.h
+++ b/src/helper.h
@@ -104,6 +104,6 @@ struct Coordinates {
 };
 
 void splitCoords(const Coordinates &original, Coordinates *&subCoords,
-                 const size_t count);
+                 const uint16_t count);
 
 #endif // HELPER_H_

--- a/src/logger.cpp
+++ b/src/logger.cpp
@@ -32,8 +32,8 @@ void verror(const char *format, fmt::format_args args) {
 
 static auto last = std::chrono::high_resolution_clock::now();
 
-void printProgress(const std::string label, const size_t current,
-                   const size_t max) {
+void printProgress(const std::string label, const uint64_t current,
+                   const uint64_t max) {
 #define PROGRESS(X) fmt::print(stderr, label + " [{:.{}f}%]\r", X, 2)
   // Keep user updated but don't spam the console
   if (!(prettyErr && prettyOut))
@@ -49,9 +49,9 @@ void printProgress(const std::string label, const size_t current,
     return;
   }
 
-  size_t ms = std::chrono::duration_cast<std::chrono::milliseconds>(
-                  std::chrono::high_resolution_clock::now() - last)
-                  .count();
+  uint32_t ms = std::chrono::duration_cast<std::chrono::milliseconds>(
+                    std::chrono::high_resolution_clock::now() - last)
+                    .count();
   // logger::info("{}/{} - {} - {}\n", current, max, ms, ms > 250);
   if (ms > 250) {
     last = std::chrono::high_resolution_clock::now();

--- a/src/logger.h
+++ b/src/logger.h
@@ -27,8 +27,8 @@ void error(const char *format, const Args &... args) {
   verror(format, fmt::make_format_args(args...));
 }
 
-void printProgress(const std::string label, const size_t current,
-                   const size_t max);
+void printProgress(const std::string label, const uint64_t current,
+                   const uint64_t max);
 
 } // namespace logger
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -93,7 +93,7 @@ int main(int argc, char **argv) {
       IsometricCanvas canvas(subCoords[i], localColors);
       canvas.shading = options.shading;
       canvas.setMarkers(options.totalMarkers, &options.markers);
-      canvas.drawTerrain(world);
+      canvas.renderTerrain(world);
 
 #pragma omp ordered
       {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -75,7 +75,7 @@ int main(int argc, char **argv) {
 #pragma omp parallel shared(finalCanvas)
   {
 #pragma omp for ordered schedule(static)
-    for (size_t i = 0; i < options.splits; i++) {
+    for (uint16_t i = 0; i < options.splits; i++) {
       // Load the minecraft terrain to render
       Terrain::Data world(subCoords[i]);
       world.load(regionDir);

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -136,7 +136,7 @@ bool Settings::parseArgs(int argc, char **argv, Settings::WorldOptions *opts) {
     return false;
   }
 
-  size_t length = opts->boundaries.maxX - opts->boundaries.minX + 1;
+  int64_t length = opts->boundaries.maxX - opts->boundaries.minX + 1;
   if (opts->splits > length) {
     logger::error("Cannot split terrain in more than {} units.\n", length);
     return false;

--- a/src/settings.h
+++ b/src/settings.h
@@ -26,8 +26,7 @@ struct WorldOptions {
   uint16_t splits;
 
   // Image settings
-  int offsetY;
-  size_t padding;
+  uint16_t padding; // Should be enough
   bool hideWater, hideBeacons, shading;
 
   // Marker storage
@@ -35,6 +34,7 @@ struct WorldOptions {
   Colors::Marker markers[256];
 
   // Memory limits, legacy code for image splitting
+  int offsetY;
   uint64_t memlimit;
   bool memlimitSet, wholeworld;
 

--- a/src/settings.h
+++ b/src/settings.h
@@ -23,7 +23,7 @@ struct WorldOptions {
   // Map boundaries
   Dimension dim;
   Coordinates boundaries;
-  size_t splits;
+  uint16_t splits;
 
   // Image settings
   int offsetY;

--- a/src/worldloader.cpp
+++ b/src/worldloader.cpp
@@ -275,47 +275,33 @@ void Terrain::Data::loadChunk(const uint32_t offset, FILE *regionHandle,
   inflateChunk(sections);
 }
 
-int16_t blockAtPost116(const uint64_t length,
+int16_t blockAtPost116(const uint64_t index_length,
                        const std::vector<int64_t> *blockStates, uint8_t x,
                        uint8_t z, uint8_t y) {
-  // The `BlockStates` array contains data on the section's blocks. You have
-  // to extract it by understanfing its structure.
-  //
-  // Although it is a array of long values, one must see it as an array of
-  // block indexes, whose element size depends on the size of the Palette.
-  // This routine locates the necessary long, extracts the block with bit
-  // comparisons, and cross-references it in the palette to get the block
-  // name.
-  //
-  // NEW in 1.16, longs are padded by 0s when a block cannot fit.
+  // NEW in 1.16, longs are padded by 0s when a block cannot fit, so no more
+  // overflow to deal with !
 
-  const uint64_t index = (x & 0x0f) + ((z & 0x0f) + (y & 0x0f) * 16) * 16;
+  const uint32_t index = (x & 0x0f) + ((z & 0x0f) + (y & 0x0f) * 16) * 16;
 
-  // The length of a block index has to be coded on the minimal possible size,
-  // which is the logarithm in base2 of the size of the palette, or 4 if the
-  // logarithm is smaller.
+  // Determine how many indexes each long holds
+  const uint8_t blocksPerLong = 64 / index_length;
 
-  // First, determine how many blocks are in each long. There is an implicit
-  // `floor` here, needed later.
-  const uint8_t blocksPerLong = 64 / length;
-
-  // Next, calculate where in the long array is the long containing the block.
-  const uint64_t longIndex = index / blocksPerLong;
+  // Calculate where in the long array is the long containing the right index.
+  const uint16_t longIndex = index / blocksPerLong;
 
   // Once we located a long, we have to know where in the 64 bits
   // the relevant block is located.
-  const uint64_t padding = (index - longIndex * blocksPerLong) * length;
+  const uint8_t padding = (index - longIndex * blocksPerLong) * index_length;
 
   // Bring the data to the first bits of the long, then extract it by bitwise
   // comparison
-  const uint64_t blockIndex =
-      ((*blockStates)[longIndex] >> padding) & ((1l << length) - 1);
+  const uint16_t blockIndex = ((*blockStates)[longIndex] >> padding) &
+                              ((uint64_t(1) << index_length) - 1);
 
-  // Lower data now contains the index in the palette
   return blockIndex;
 }
 
-int16_t blockAtPre116(const uint64_t length,
+int16_t blockAtPre116(const uint64_t index_length,
                       const std::vector<int64_t> *blockStates, uint8_t x,
                       uint8_t z, uint8_t y) {
   // The `BlockStates` array contains data on the section's blocks. You have to
@@ -324,36 +310,61 @@ int16_t blockAtPre116(const uint64_t length,
   // Although it is a array of long values, one must see it as an array of block
   // indexes, whose element size depends on the size of the Palette. This
   // routine locates the necessary long, extracts the block with bit
-  // comparisons, and cross-references it in the palette to get the block name.
-
-  const uint64_t index = (x & 0x0f) + ((z & 0x0f) + (y & 0x0f) * 16) * 16;
-
+  // comparisons.
+  //
   // The length of a block index has to be coded on the minimal possible size,
   // which is the logarithm in base2 of the size of the palette, or 4 if the
   // logarithm is smaller.
 
+  // The index of the block in the section itself, if every block had a number
+  // according to its order
+  const uint32_t index = (x & 0x0f) + ((z & 0x0f) + (y & 0x0f) * 16) * 16;
+
   // We skip the `position` first blocks, of length `size`, then divide by 64 to
   // get the number of longs to skip from the array
-  const uint64_t skip_longs = index * length >> 6;
+  const uint16_t skip_longs = (index * index_length) >> 6;
 
   // Once we located the data in a long, we have to know where in the 64 bits it
   // is located. This is the remaining of the previous operation
-  const int64_t padding = index * length & 63;
+  const int8_t padding = (index * index_length) & 63;
 
-  // Craft a mask from the length of the block index and the padding, the apply
-  // it to the long
-  const uint64_t mask = ((1l << length) - 1) << padding;
-  uint64_t lower_data = ((*blockStates)[skip_longs] & mask) >> padding;
+  // Sometimes the data of an index does not fit entirely into a long, so we
+  // check if there is overflow
+  const int8_t overflow =
+      (padding + index_length > 64 ? padding + index_length - 64 : 0);
 
-  // Sometimes the length of the index does not fall entirely into a long, so
-  // here we check if there is overflow and extract it too
-  const int64_t overflow = padding + length - 64;
+  // This complicated expression extracts the necessary bits from the current
+  // long.
+  //
+  // Lets say we need the following bits in a long (not to scale):
+  // 10011100111001110011100
+  //    ^^^^^
+  // We do this by shifting (>>) the data by padding, to get the relevant bits
+  // on the end of the long:
+  // ???????????????10011100
+  //                   ^^^^^
+  // We then apply a mask to get only the relevant bits:
+  // ???????????????10011100
+  // 00000000000000000011111 &
+  // 00000000000000000011100 <- result
+  //
+  // The mask is made at the size of the data, using the formula (1 << n) - 1,
+  // the resulting bitset is of the following shape: 0...01...1 with n 1s.
+  //
+  // If there is an overflow, the mask size is reduced, as not to catch noise
+  // from the padding (ie the interrogation points earlier) that appear on
+  // ARM32.
+  uint16_t lower_data = ((*blockStates)[skip_longs] >> padding) &
+                        ((uint64_t(1) << (index_length - overflow)) - 1);
+
   if (overflow > 0) {
-    const uint64_t upper_data =
-        (*blockStates)[skip_longs + 1] & ((1l << overflow) - 1);
-    lower_data = lower_data | upper_data << (length - overflow);
+    // The exact same process is used to catch the overflow from the next long
+    const uint16_t upper_data =
+        ((*blockStates)[skip_longs + 1]) & ((uint64_t(1) << overflow) - 1);
+    // We then associate both values to create the final value
+    lower_data = lower_data | (upper_data << (index_length - overflow));
   }
 
-  // Lower data now contains the index in the palette
+  // lower_data now contains the index in the palette
   return lower_data;
 }

--- a/src/worldloader.cpp
+++ b/src/worldloader.cpp
@@ -207,7 +207,7 @@ bool decompressChunk(const uint32_t offset, FILE *regionHandle,
   }
 
   *length = _ntohl(zData);
-  // len--; // This dates from Zahl's, no idea of its purpose
+  (*length)--; // Sometimes the data is 1 byte smaller
 
   if (fread(zData, sizeof(uint8_t), *length, regionHandle) != *length) {
     logger::error("Not enough data for chunk: {}\n", strerror(errno));

--- a/src/worldloader.cpp
+++ b/src/worldloader.cpp
@@ -25,7 +25,7 @@ void scanWorldDirectory(const std::filesystem::path &regionDir,
     regionZ = atoi(index.c_str());
 
     std::ifstream regionData(region.path());
-    for (size_t chunk = 0; chunk < REGIONSIZE * REGIONSIZE; chunk++) {
+    for (uint16_t chunk = 0; chunk < REGIONSIZE * REGIONSIZE; chunk++) {
       regionData.read(buffer, 4);
 
       if (*((uint32_t *)&buffer) == 0) {

--- a/src/worldloader.h
+++ b/src/worldloader.h
@@ -33,7 +33,7 @@ struct Data {
 
   // The internal list of chunks, of size chunkLen
   ChunkList chunks;
-  size_t chunkLen;
+  uint64_t chunkLen;
 
   // An array of bytes, one for each chunk
   // the first 4 bits are the highest section number,
@@ -54,7 +54,7 @@ struct Data {
     map.maxZ = CHUNK(coords.maxZ);
 
     chunkLen =
-        size_t(map.maxX - map.minX + 1) * size_t(map.maxZ - map.minZ + 1);
+        uint64_t(map.maxX - map.minX + 1) * uint64_t(map.maxZ - map.minZ + 1);
 
     chunks = new Terrain::Chunk[chunkLen];
     heightMap = new uint8_t[chunkLen];
@@ -80,7 +80,7 @@ struct Data {
   uint8_t importHeight(vector<NBT> *);
   void inflateChunk(vector<NBT> *);
 
-  size_t chunkIndex(int64_t x, int64_t z) const {
+  uint64_t chunkIndex(int64_t x, int64_t z) const {
     return (x - map.minX) + (z - map.minZ) * (map.maxX - map.minX + 1);
   }
 


### PR DESCRIPTION
I discarded previous attemps at cross-compatibility, thinking that nobody would ever run mcmap on a 32bit system again, yet here we are.

The hard limits on map and image size imposed by this change are the following:
- Practical max image size: 2^32x2^32.
- Therorical max terrain size: 2^32x2^32 in memory, but the limiting factor is the image. Somewhere in the code is the following formula: the size of an image for a given world is the sum of its width and length (x and z axis) times 2. For a square world, this leads us to a max size of 2^32 = n*2*2, so a limit of n = 2^28 blocks.

This means a limit of 524288 region files on each axis, where we still are ten times above the minecraft size limits.