### PR TITLE
Self-serve chunk loading

### DIFF
--- a/src/canvas.cpp
+++ b/src/canvas.cpp
@@ -51,7 +51,7 @@ void IsometricCanvas::setColors(const Colors::Palette &colors) {
     brightnessLookup[y] = -100 + 200 * float(y) / 255;
 }
 
-void IsometricCanvas::setMap(const Coordinates &_map) {
+void IsometricCanvas::setMap(const Terrain::Coordinates &_map) {
   map = _map;
 
   nXChunks = CHUNK(map.maxX) - CHUNK(map.minX) + 1;

--- a/src/canvas.cpp
+++ b/src/canvas.cpp
@@ -10,16 +10,48 @@
 // | |__| (_) | | | \__ \ |_| |  | |_| | (__| || (_) | |  \__ \.
 //  \____\___/|_| |_|___/\__|_|   \__,_|\___|\__\___/|_|  |___/
 
-IsometricCanvas::IsometricCanvas(const Terrain::Coordinates &coords,
-                                 const Colors::Palette &colors,
-                                 const uint16_t padding)
-    : map(coords), padding(padding) {
+IsometricCanvas::IsometricCanvas() {
   // This is a legacy setting, changing how the map is drawn. It can be 2 or
   // 3; it means that a block is drawn with a 2 or 3 pixel offset over the
   // block under it. This changes the orientation of the map: but it totally
   // changes the drawing of special blocks, and as no special cases can be
   // made easily, I set it to 3 for now.
   heightOffset = 3;
+}
+
+void IsometricCanvas::setColors(const Colors::Palette &colors) {
+  // Setting and pre-caching colors
+  palette = colors;
+
+  auto beamColor = colors.find("mcmap:beacon_beam");
+  if (beamColor != colors.end())
+    beaconBeam = beamColor->second;
+
+  auto waterColor = colors.find("minecraft:water");
+  if (waterColor != colors.end())
+    water = waterColor->second;
+
+  auto airColor = colors.find("minecraft:air");
+  if (airColor != colors.end())
+    air = airColor->second;
+
+  // Set to true to use shading later on
+  shading = false;
+  // Precompute the shading profile. The values are arbitrary, and will go
+  // through Colors::Color.modcolor further down the code. The 255 array
+  // represents the entire world height. This profile is linear, going from
+  // -100 at height 0 to 100 at height 255. This replaced a convoluted formula
+  // that did a much better job of higlighting overground terrain, but would
+  // look weird in other dimensions.
+  // Legacy formula: ((100.0f / (1.0f + exp(- (1.3f * (float(y) *
+  // MIN(g_MapsizeY, 200) / g_MapsizeY) / 16.0f) + 6.0f))) - 91)
+  brightnessLookup = new float[255];
+  for (int y = 0; y < 255; ++y)
+    brightnessLookup[y] = -100 + 200 * float(y) / 255;
+}
+
+void IsometricCanvas::setMap(const Coordinates &_map) {
+  map = _map;
 
   nXChunks = CHUNK(map.maxX) - CHUNK(map.minX) + 1;
   nZChunks = CHUNK(map.maxZ) - CHUNK(map.minZ) + 1;
@@ -57,43 +89,13 @@ IsometricCanvas::IsometricCanvas(const Terrain::Coordinates &coords,
   // => A chunk's width equals its size on each side times 2.
   // By generalizing this formula, the entire map's size equals the sum of its
   // length on both the horizontal axis times 2.
-  width = (sizeX + sizeZ + this->padding) * 2;
+  width = (sizeX + sizeZ) * 2;
 
-  height =
-      sizeX + sizeZ + (256 - map.minY) * heightOffset + this->padding * 2 + 1;
+  height = sizeX + sizeZ + (256 - map.minY) * heightOffset + 1;
 
   size = uint64_t(width * height * BYTESPERPIXEL);
   bytesBuffer = new uint8_t[size];
   memset(bytesBuffer, 0, size);
-
-  // Setting and pre-caching colors
-  palette = colors;
-
-  auto beamColor = colors.find("mcmap:beacon_beam");
-  if (beamColor != colors.end())
-    beaconBeam = beamColor->second;
-
-  auto waterColor = colors.find("minecraft:water");
-  if (waterColor != colors.end())
-    water = waterColor->second;
-
-  auto airColor = colors.find("minecraft:air");
-  if (airColor != colors.end())
-    air = airColor->second;
-
-  // Set to true to use shading later on
-  shading = false;
-  // Precompute the shading profile. The values are arbitrary, and will go
-  // through Colors::Color.modcolor further down the code. The 255 array
-  // represents the entire world height. This profile is linear, going from
-  // -100 at height 0 to 100 at height 255. This replaced a convoluted formula
-  // that did a much better job of higlighting overground terrain, but would
-  // look weird in other dimensions.
-  // Legacy formula: ((100.0f / (1.0f + exp(- (1.3f * (float(y) *
-  // MIN(g_MapsizeY, 200) / g_MapsizeY) / 16.0f) + 6.0f))) - 91)
-  brightnessLookup = new float[255];
-  for (int y = 0; y < 255; ++y)
-    brightnessLookup[y] = -100 + 200 * float(y) / 255;
 }
 
 //  ____                       _
@@ -124,7 +126,7 @@ uint32_t IsometricCanvas::firstLine() const {
         line = row;
 
   // Return the value plus padding, to ensure the space before
-  return line - padding;
+  return line;
 }
 
 uint32_t IsometricCanvas::lastLine() const {
@@ -137,14 +139,14 @@ uint32_t IsometricCanvas::lastLine() const {
         line = row;
 
   // Return the value plus padding, to ensure the space after
-  return line + padding;
+  return line;
 }
 
 uint32_t IsometricCanvas::getCroppedHeight() const {
   uint32_t croppedHeight = lastLine() - firstLine();
 
   // If the two values are just the padding hardcoded
-  if (croppedHeight == int64_t(padding) * 2)
+  if (!croppedHeight)
     return 0;
 
   return croppedHeight + 1;
@@ -437,8 +439,7 @@ inline void IsometricCanvas::renderBlock(const Colors::Block *color, uint32_t x,
 
   const uint32_t bmpPosX = // The formula is:
       2 * (sizeZ - 1)      // From the middle of the image
-      + (x - z) * 2 // Calc the offset (greater x on the right, z to the left)
-      + padding;    // Add padding by moving to the right
+      + (x - z) * 2; // Calc the offset (greater x on the right, z to the left)
 
   // To get the height of a pixel, we have to look at how a flat layer
   // articulates:
@@ -458,7 +459,6 @@ inline void IsometricCanvas::renderBlock(const Colors::Block *color, uint32_t x,
   const uint32_t bmpPosY = // The formula for the base is:
       height               // Starting from the bottom -1,
       - 2                  // Remove the rest of the height of a block,
-      - padding            // Remove the padding (Adding space to the bottom),
 
       // We add x and z for the depth, so that the final block is on the
       // bottom
@@ -561,10 +561,6 @@ uint64_t IsometricCanvas::calcAnchor(const IsometricCanvas &subCanvas) {
     anchorY = height - minOffset;
     break;
   }
-
-  // Adjust the padding before translating to an offset
-  anchorX = anchorX + padding - subCanvas.padding;
-  anchorY = anchorY - padding + subCanvas.padding;
 
   // Translate those coordinates as an offset from the beginning of the
   // buffer

--- a/src/canvas.cpp
+++ b/src/canvas.cpp
@@ -545,7 +545,6 @@ CompositeCanvas::CompositeCanvas(const std::vector<IsometricCanvas> &parts) {
     // This one is simpler, the vertical distance being equal to the distance
     // between top corners.
     oY = oriented.minX - map.minX + oriented.minZ - map.minZ;
-    logger::debug("Subcanvas height {}\n", canvas.height);
 
     // Add this to the list of positions
     subCanvasses[i] = {oX, oY, &canvas};

--- a/src/canvas.cpp
+++ b/src/canvas.cpp
@@ -192,7 +192,7 @@ void IsometricCanvas::orientChunk(int32_t &x, int32_t &z) {
   }
 }
 
-void IsometricCanvas::renderTerrain(const Terrain::Data &world) {
+void IsometricCanvas::renderTerrain(Terrain::Data &world) {
   // world is supposed to have the SAME set of coordinates as the canvas
   for (chunkX = 0; chunkX < nXChunks; chunkX++) {
     for (chunkZ = 0; chunkZ < nZChunks; chunkZ++) {
@@ -205,11 +205,11 @@ void IsometricCanvas::renderTerrain(const Terrain::Data &world) {
   return;
 }
 
-void IsometricCanvas::renderChunk(const Terrain::Data &terrain) {
+void IsometricCanvas::renderChunk(Terrain::Data &terrain) {
   int32_t worldX = chunkX, worldZ = chunkZ;
   orientChunk(worldX, worldZ);
 
-  const NBT &chunk = terrain.chunkAt(worldX, worldZ);
+  NBT &chunk = terrain.chunkAt(worldX, worldZ);
   const uint8_t minHeight = terrain.minHeight(worldX, worldZ),
                 maxHeight = terrain.maxHeight(worldX, worldZ);
 
@@ -248,6 +248,8 @@ void IsometricCanvas::renderChunk(const Terrain::Data &terrain) {
     }
 
   beamNo = 0;
+
+  chunk.erase("Level");
 }
 
 // A bit like the above: where do we begin rendering in the 16x16 horizontal

--- a/src/canvas.cpp
+++ b/src/canvas.cpp
@@ -537,7 +537,6 @@ std::string CompositeCanvas::to_string() {
 
 size_t CompositeCanvas::getLine(uint8_t *buffer, size_t size,
                                 uint64_t y) const {
-  memset(buffer, 0, size);
   size_t written = 0;
 
   for (auto &pos : subCanvasses) {

--- a/src/canvas.h
+++ b/src/canvas.h
@@ -44,8 +44,7 @@ struct IsometricCanvas {
   uint8_t offsetX, offsetZ; // Offset of the first block in the first chunk
 
   uint32_t width, height; // Bitmap width and height
-  uint16_t padding;       // Padding inside the image
-  uint8_t heightOffset;   // Offset for block rendering
+  uint8_t heightOffset;   // Offset of the first block in the first chunk
 
   uint8_t *bytesBuffer; // The buffer where pixels are written
   uint64_t size;        // The size of the buffer
@@ -75,11 +74,12 @@ struct IsometricCanvas {
 
   uint8_t orientedX, orientedZ, y;
 
-  IsometricCanvas(const Terrain::Coordinates &coords,
-                  const Colors::Palette &colors, const uint16_t padding = 0);
+  IsometricCanvas();
 
   ~IsometricCanvas() { delete[] bytesBuffer; }
 
+  void setColors(const Colors::Palette &);
+  void setMap(const Coordinates &);
   void setMarkers(uint8_t n, Colors::Marker (*array)[256]) {
     totalMarkers = n;
     markers = array;

--- a/src/canvas.h
+++ b/src/canvas.h
@@ -138,7 +138,7 @@ struct CompositeCanvas {
 
   struct Position {
     // Struct holding metadata about where the subCanvas is to be drawn.
-    uint32_t offsetX, offsetY;        // Offsets to draw the image
+    int64_t offsetX, offsetY;         // Offsets to draw the image
     const IsometricCanvas *subCanvas; // Canvas to draw
   };
 

--- a/src/canvas.h
+++ b/src/canvas.h
@@ -39,7 +39,7 @@ struct Beam {
 struct IsometricCanvas {
   bool shading;
 
-  Coordinates map;          // The coordinates describing the 3D map
+  Terrain::Coordinates map; // The coordinates describing the 3D map
   uint32_t sizeX, sizeZ;    // The size of the 3D map
   uint8_t offsetX, offsetZ; // Offset of the first block in the first chunk
 
@@ -79,7 +79,7 @@ struct IsometricCanvas {
   ~IsometricCanvas() { delete[] bytesBuffer; }
 
   void setColors(const Colors::Palette &);
-  void setMap(const Coordinates &);
+  void setMap(const Terrain::Coordinates &);
   void setMarkers(uint8_t n, Colors::Marker (*array)[256]) {
     totalMarkers = n;
     markers = array;
@@ -111,7 +111,7 @@ struct IsometricCanvas {
 // A sparse canvas made with smaller canvasses
 struct CompositeCanvas {
   uint64_t width, height;
-  Coordinates map;
+  Terrain::Coordinates map;
 
   struct Position {
     uint32_t offsetX, offsetY;

--- a/src/canvas.h
+++ b/src/canvas.h
@@ -85,26 +85,6 @@ struct IsometricCanvas {
     markers = array;
   }
 
-  // Cropping methods
-  // Those getters return a value inferior to the actual underlying values
-  // leaving out empty areas, to essentially 'crop' the canvas to fit perfectly
-  // the image
-  uint32_t getCroppedWidth() const;
-  uint32_t getCroppedHeight() const;
-
-  uint64_t getCroppedSize() const {
-    return getCroppedWidth() * getCroppedHeight();
-  }
-  uint64_t getCroppedOffset() const;
-
-  // Line indexes
-  uint32_t firstLine() const;
-  uint32_t lastLine() const;
-
-  // Merging methods
-  void merge(const IsometricCanvas &subCanvas);
-  uint64_t calcAnchor(const IsometricCanvas &subCanvas);
-
   // Drawing methods
   // Helpers for position lookup
   void orientChunk(int32_t &x, int32_t &z);
@@ -125,6 +105,26 @@ struct IsometricCanvas {
   void renderBeamSection(const int64_t, const int64_t, const uint8_t);
 
   const Colors::Block *nextBlock();
+  size_t getLine(uint8_t *, size_t, uint64_t) const;
+};
+
+// A sparse canvas made with smaller canvasses
+struct CompositeCanvas {
+  uint64_t width, height;
+  Coordinates map;
+
+  struct Position {
+    uint32_t offsetX, offsetY;
+    const IsometricCanvas *subCanvas;
+  };
+
+  std::vector<Position> subCanvasses;
+
+  CompositeCanvas(const std::vector<IsometricCanvas> &);
+
+  std::string to_string();
+
+  size_t getLine(uint8_t *, size_t, uint64_t) const;
 };
 
 #endif

--- a/src/canvas.h
+++ b/src/canvas.h
@@ -114,8 +114,8 @@ struct IsometricCanvas {
   }
 
   // Drawing entrypoints
-  void renderTerrain(const Terrain::Data &);
-  void renderChunk(const Terrain::Data &);
+  void renderTerrain(Terrain::Data &);
+  void renderChunk(Terrain::Data &);
   void renderSection();
   // Draw a block from virtual coords in the canvas
   void renderBlock(const Colors::Block *, const uint32_t, const uint32_t,

--- a/src/draw_png.cpp
+++ b/src/draw_png.cpp
@@ -105,16 +105,28 @@ bool Image::save() {
     return false;
   }
 
-  logger::info("Writing to file...\n");
+#ifdef CLOCK
+  static auto last = std::chrono::high_resolution_clock::now();
+#endif
+
   for (uint64_t y = 0; y < canvas->height; ++y) {
+    logger::printProgress("Composing final PNG", y, canvas->height);
     canvas->getLine(buffer, bufSize - padding * BYTESPERPIXEL, y);
     png_write_row(pngPtr, (png_bytep)buffer);
   }
 
-  delete[] buffer;
-
   png_write_end(pngPtr, NULL);
   png_destroy_write_struct(&pngPtr, &pngInfoPtr);
+
+  delete[] buffer;
+
+#ifdef CLOCK
+  uint32_t ms = std::chrono::duration_cast<std::chrono::milliseconds>(
+                    std::chrono::high_resolution_clock::now() - last)
+                    .count();
+
+  logger::debug("Rendered canvas in {}ms\n", ms);
+#endif
 
   return true;
 }

--- a/src/draw_png.h
+++ b/src/draw_png.h
@@ -11,20 +11,7 @@
 #include "./worldloader.h"
 #include "colors.h"
 #include "helper.h"
-#include <cstdio>
-#include <cstdlib>
-#include <cstring>
-#include <ctime>
-#include <functional>
-#include <list>
 #include <png.h>
-#include <utility>
-#ifndef _WIN32
-#include <sys/stat.h>
-#endif
-#if defined(_WIN32) && !defined(__GNUC__)
-#include <direct.h>
-#endif
 
 namespace PNG {
 

--- a/src/draw_png.h
+++ b/src/draw_png.h
@@ -31,13 +31,15 @@ namespace PNG {
 struct Image {
   FILE *imageHandle;
 
+  uint8_t padding;
   png_structp pngPtr;
   png_infop pngInfoPtr;
-  const IsometricCanvas *canvas;
+  const CompositeCanvas *canvas;
 
   bool ready = false;
 
-  Image(const std::filesystem::path file, const IsometricCanvas *pixels);
+  Image(const std::filesystem::path file, const CompositeCanvas *contents,
+        uint8_t padding = 0);
 
   ~Image() {
     if (imageHandle)

--- a/src/helper.cpp
+++ b/src/helper.cpp
@@ -32,8 +32,8 @@ bool isNumeric(const char *str) {
   return true;
 }
 
-void splitCoords(const Coordinates &original, Coordinates *&subCoords,
-                 const uint16_t count) {
+void splitCoords(const Coordinates<int32_t> &original,
+                 Coordinates<int32_t> *subCoords, const uint16_t count) {
   // Split the coordinates of the entire terrain in `count` terrain fragments
 
   for (uint16_t index = 0; index < count; index++) {

--- a/src/helper.cpp
+++ b/src/helper.cpp
@@ -35,6 +35,12 @@ bool isNumeric(const char *str) {
 void splitCoords(const Coordinates<int32_t> &original,
                  Coordinates<int32_t> *subCoords, const uint16_t count) {
   // Split the coordinates of the entire terrain in `count` terrain fragments
+  uint32_t width = (original.sizeX() + original.sizeZ()) * 2;
+  uint32_t height = original.sizeX() + original.sizeZ() +
+                    (original.maxY - original.minY + 1) * 3 - 1;
+  logger::debug("Rendering map {} requires a {}x{} image of {}MB\n",
+                original.to_string(), width, height,
+                width * height * 4 / (1024 * 1024));
 
   for (uint16_t index = 0; index < count; index++) {
     // Initialization with the original's values
@@ -53,5 +59,14 @@ void splitCoords(const Coordinates<int32_t> &original,
     // covered
     if (index == count - 1)
       subCoords[index].maxX = original.maxX;
+  }
+
+  if (count > 1) {
+    width = (subCoords[0].sizeX() + subCoords[0].sizeZ()) * 2;
+    height = subCoords[0].sizeX() + subCoords[0].sizeZ() +
+             (subCoords[0].maxY - subCoords[0].minY + 1) * 3 - 1;
+    logger::debug("Splitting into {} maps requiring {} {}x{} images of {}MB\n",
+                  count, count, width, height,
+                  width * height * 4 / (1024 * 1024));
   }
 }

--- a/src/helper.h
+++ b/src/helper.h
@@ -49,6 +49,8 @@ struct Coordinates {
   void setUndefined() {
     minX = minZ = std::numeric_limits<Integer>::max();
     maxX = maxZ = std::numeric_limits<Integer>::min();
+    minY = std::numeric_limits<uint8_t>::max();
+    maxY = std::numeric_limits<uint8_t>::min();
   }
 
   bool isUndefined() {
@@ -64,7 +66,8 @@ struct Coordinates {
   }
 
   std::string to_string() const {
-    return fmt::format("x{} z{} to x{} z{}", minX, minZ, maxX, maxZ);
+    return fmt::format("x{} z{} y{} to x{} z{} y{}", minX, minZ, minY, maxX,
+                       maxZ, maxY);
   }
 
   void rotate() {

--- a/src/helper.h
+++ b/src/helper.h
@@ -66,6 +66,25 @@ struct Coordinates {
   std::string to_string() const {
     return fmt::format("x{} z{} to x{} z{}", minX, minZ, maxX, maxZ);
   }
+
+  void rotate() {
+    std::swap(minX, minZ);
+    std::swap(maxX, maxZ);
+    std::swap(minX, maxX);
+    minX = -minX;
+    maxX = -maxX;
+  };
+
+  Coordinates<Integer> orient(Orientation o) const {
+    Coordinates<Integer> oriented = *this;
+
+    for (int i = 0; i < (4 + o - orientation) % 4; i++)
+      oriented.rotate();
+
+    oriented.orientation = o;
+
+    return oriented;
+  };
 };
 
 void splitCoords(const Coordinates<int32_t> &original,

--- a/src/helper.h
+++ b/src/helper.h
@@ -30,8 +30,10 @@ enum Orientation {
 };
 
 // A simple coordinates structure
+template <typename Integer,
+          std::enable_if_t<std::is_integral<Integer>::value, int> = 0>
 struct Coordinates {
-  int32_t minX, maxX, minZ, maxZ;
+  Integer minX, maxX, minZ, maxZ;
   uint8_t minY, maxY;
   Orientation orientation;
 
@@ -40,18 +42,18 @@ struct Coordinates {
     orientation = NW;
   }
 
-  Coordinates(int32_t init) : Coordinates() {
+  Coordinates(Integer init) : Coordinates() {
     minX = maxX = minZ = maxZ = init;
   }
 
   void setUndefined() {
-    minX = minZ = std::numeric_limits<int32_t>::max();
-    maxX = maxZ = std::numeric_limits<int32_t>::min();
+    minX = minZ = std::numeric_limits<Integer>::max();
+    maxX = maxZ = std::numeric_limits<Integer>::min();
   }
 
   bool isUndefined() {
-    return (minX == minZ && minX == std::numeric_limits<int32_t>::max() &&
-            maxX == maxZ && maxX == std::numeric_limits<int32_t>::min());
+    return (minX == minZ && minX == std::numeric_limits<Integer>::max() &&
+            maxX == maxZ && maxX == std::numeric_limits<Integer>::min());
   }
 
   void crop(const Coordinates &boundaries) {
@@ -66,7 +68,7 @@ struct Coordinates {
   }
 };
 
-void splitCoords(const Coordinates &original, Coordinates *&subCoords,
-                 const uint16_t count);
+void splitCoords(const Coordinates<int32_t> &original,
+                 Coordinates<int32_t> *subCoords, const uint16_t count);
 
 #endif // HELPER_H_

--- a/src/helper.h
+++ b/src/helper.h
@@ -1,38 +1,9 @@
 #ifndef HELPER_H_
 #define HELPER_H_
 
+#include "./logger.h"
 #include <algorithm>
-#include <chrono>
-#include <cstdio>
-#include <cstring>
-#include <ctime>
-#include <limits>
-#include <sstream>
-#include <stdint.h>
 #include <string>
-#include <sys/stat.h>
-#include <sys/types.h>
-
-// Difference between MSVC++ and gcc/others
-#if defined(_WIN32) && !defined(__GNUC__)
-#include <windows.h>
-#define usleep(x) Sleep((x) / 1000);
-#define isatty(x) 0
-#else
-#include <unistd.h>
-#endif
-
-// For fseek
-#if defined(_WIN32) && !defined(__GNUC__)
-// MSVC++
-#define fseek64 _fseeki64
-#elif defined(__APPLE__)
-#define fseek64 fseeko
-#elif defined(__FreeBSD__)
-#define fseek64 fseeko
-#else
-#define fseek64 fseeko64
-#endif
 
 #define CHUNKSIZE 16
 #define REGIONSIZE 32
@@ -91,11 +62,7 @@ struct Coordinates {
   }
 
   std::string to_string() const {
-    std::stringstream ss;
-    ss << "From x:" << minX << " z:" << minZ << " to x:" << maxX
-       << " z:" << maxZ;
-
-    return ss.str();
+    return fmt::format("x{} z{} to x{} z{}", minX, minZ, maxX, maxZ);
   }
 };
 

--- a/src/helper.h
+++ b/src/helper.h
@@ -68,11 +68,11 @@ struct Coordinates {
   }
 
   void rotate() {
-    std::swap(minX, minZ);
-    std::swap(maxX, maxZ);
     std::swap(minX, maxX);
     minX = -minX;
     maxX = -maxX;
+    std::swap(minX, minZ);
+    std::swap(maxX, maxZ);
   };
 
   Coordinates<Integer> orient(Orientation o) const {
@@ -85,6 +85,9 @@ struct Coordinates {
 
     return oriented;
   };
+
+  inline Integer sizeX() const { return maxX - minX + 1; }
+  inline Integer sizeZ() const { return maxZ - minZ + 1; }
 };
 
 void splitCoords(const Coordinates<int32_t> &original,

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -100,13 +100,8 @@ int main(int argc, char **argv) {
       subCoords[i].minY = std::max(subCoords[i].minY, world.minHeight());
       subCoords[i].maxY = std::min(subCoords[i].maxY, world.maxHeight());
 
-      // Pre-cache the colors used in the part of the world loaded to squeeze a
-      // few milliseconds of color lookup
-      Colors::Palette localColors;
-      Colors::filter(colors, world.cache, &localColors);
-
       // Draw the terrain fragment
-      IsometricCanvas canvas(subCoords[i], localColors);
+      IsometricCanvas canvas(subCoords[i], colors);
       canvas.shading = options.shading;
       canvas.setMarkers(options.totalMarkers, &options.markers);
       canvas.renderTerrain(world);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -112,9 +112,12 @@ int main(int argc, char **argv) {
     }
   }
 
+  logger::info("{}\n", CompositeCanvas(subCanvasses).to_string());
+
   delete[] subCoords;
 
-  PNG::Image(options.outFile, &subCanvasses[0]).save();
+  CompositeCanvas merged(subCanvasses);
+  PNG::Image(options.outFile, &merged, 0).save();
   logger::info("Job complete.\n");
 
   return 0;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -112,6 +112,7 @@ int main(int argc, char **argv) {
   delete[] subCoords;
 
   CompositeCanvas merged(subCanvasses);
+  logger::debug("{}\n", merged.to_string());
   PNG::Image(options.outFile, &merged, 0).save();
   logger::info("Job complete.\n");
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -10,9 +10,6 @@
 
 using std::string;
 
-void printHelp(char *binary);
-void render(IsometricCanvas *canvas, const Terrain::Data &world);
-
 void printHelp(char *binary) {
   logger::info(
       "Usage: {} <options> WORLDPATH\n\n"
@@ -111,8 +108,6 @@ int main(int argc, char **argv) {
       canvas.renderTerrain(world);
     }
   }
-
-  logger::info("{}\n", CompositeCanvas(subCanvasses).to_string());
 
   delete[] subCoords;
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -113,7 +113,7 @@ int main(int argc, char **argv) {
 
   CompositeCanvas merged(subCanvasses);
   logger::debug("{}\n", merged.to_string());
-  PNG::Image(options.outFile, &merged, 0).save();
+  PNG::Image(options.outFile, &merged, options.padding).save();
   logger::info("Job complete.\n");
 
   return 0;

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -4,6 +4,9 @@
 #define ISPATH(p) (!(p).empty() && std::filesystem::exists((p)))
 
 bool Settings::parseArgs(int argc, char **argv, Settings::WorldOptions *opts) {
+  opts->boundaries.setUndefined();
+  opts->boundaries.minY = 0;
+  opts->boundaries.maxY = 255;
 #define MOREARGS(x) (argpos + (x) < argc)
 #define NEXTARG argv[++argpos]
 #define POLLARG(x) argv[argpos + (x)]
@@ -154,6 +157,7 @@ bool Settings::parseArgs(int argc, char **argv, Settings::WorldOptions *opts) {
 
     if (opts->boundaries.maxX < opts->boundaries.minX ||
         opts->boundaries.maxZ < opts->boundaries.minZ) {
+      logger::debug("{}\n", opts->boundaries.to_string());
       logger::error("Nothing to render: -from X Z has to be <= -to X Z\n");
       return false;
     }

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -137,8 +137,8 @@ bool Settings::parseArgs(int argc, char **argv, Settings::WorldOptions *opts) {
 
     // Scan the region directory and map the existing terrain in this set of
     // coordinates
-    Coordinates existingWorld;
-    scanWorldDirectory(opts->regionDir(), &existingWorld);
+    Terrain::Coordinates existingWorld;
+    Terrain::scanWorldDirectory(opts->regionDir(), &existingWorld);
 
     if (opts->boundaries.isUndefined()) {
       // No boundaries were defined, import the whole existing world

--- a/src/settings.h
+++ b/src/settings.h
@@ -55,7 +55,7 @@ struct WorldOptions {
   // Map boundaries
   Dimension dim;
   std::string customDim;
-  Coordinates boundaries;
+  Terrain::Coordinates boundaries;
   uint16_t splits;
 
   // Image settings

--- a/src/worldloader.cpp
+++ b/src/worldloader.cpp
@@ -3,8 +3,8 @@
 
 NBT minecraft_air(nbt::tag_type::tag_end);
 
-void scanWorldDirectory(const std::filesystem::path &regionDir,
-                        Coordinates *savedWorld) {
+void Terrain::scanWorldDirectory(const std::filesystem::path &regionDir,
+                                 Terrain::Coordinates *savedWorld) {
   const char delimiter = '.';
   std::string index;
   char buffer[4];

--- a/src/worldloader.h
+++ b/src/worldloader.h
@@ -45,6 +45,9 @@ struct Data {
 
   vector<string> cache;
 
+  std::filesystem::path regionDir;
+  Chunk empty;
+
   // Default constructor
   explicit Data(const Terrain::Coordinates &coords) : heightBounds(0) {
     map.minX = CHUNK(coords.minX);
@@ -81,12 +84,10 @@ struct Data {
     return (x - map.minX) + (z - map.minZ) * (map.maxX - map.minX + 1);
   }
 
-  const NBT &chunkAt(int64_t xPos, int64_t zPos) const {
-    return chunks[chunkIndex(xPos, zPos)];
-  }
+  NBT &chunkAt(int64_t xPos, int64_t zPos);
 
-  uint8_t maxHeight() const { return heightBounds >> 8; }
-  uint8_t minHeight() const { return heightBounds & 0xff; }
+  uint8_t maxHeight() const { return 255; }
+  uint8_t minHeight() const { return 0; }
 
   uint8_t maxHeight(const int64_t x, const int64_t z) const {
     return heightMap[chunkIndex(x, z)] >> 8;

--- a/src/worldloader.h
+++ b/src/worldloader.h
@@ -16,14 +16,14 @@ using nbt::NBT;
 using std::string;
 using std::vector;
 
-void scanWorldDirectory(const std::filesystem::path &, Coordinates *);
-
 namespace Terrain {
 
 typedef NBT Chunk;
 typedef Chunk *ChunkList;
 
-using Coordinates = struct Coordinates;
+using Coordinates = Coordinates<int32_t>;
+
+void scanWorldDirectory(const std::filesystem::path &, Coordinates *);
 
 struct Data {
   // The coordinates of the loaded chunks. This coordinates maps


### PR DESCRIPTION
Loading individual chunks by loading and unloading them for each use allows for a significant drop in memory usage.
For instance, this is the memory profile from the main branch:
![before](https://user-images.githubusercontent.com/22240065/97248960-219c8e80-17c0-11eb-9d00-446ac2f72011.png)

With an initial buffer allocation for the image, a subsequent ramp-up to load the entire terrain, and a final buffer allocation for the sub-canvas.

The new behavior skips the loading phase, and the initial buffer allocation:
![after](https://user-images.githubusercontent.com/22240065/97249270-c4eda380-17c0-11eb-9db0-d5c71d960c0d.png)

Both those profiles were calculated on the same world of size ~ 6000x6000.

To accomodate such changes, the entire merging code has been revamped. From there, tiling and file caching will be straightforward to implement.