### PR TITLE
Enable circular renders

### DIFF
--- a/src/canvas.cpp
+++ b/src/canvas.cpp
@@ -352,11 +352,21 @@ void IsometricCanvas::renderSection(const Section &section) {
       orientedX = x, orientedZ = z;
       orientSection(orientedX, orientedZ);
 
+      // These get used a few times; calculate them once.
+      int px = (worldX << 4) + orientedX;
+      int pz = (worldZ << 4) + orientedZ;
+
+      // If we want a circular render, ignore everything outside the radius.
+      if (map.circleDefined()) {
+        int dist = (px - map.cenX) * (px - map.cenX) +
+                   (pz - map.cenZ) * (pz - map.cenZ);
+        if (dist > map.rsqrd) {
+          continue;
+        }
+      }
+
       // If we are oob, skip the line
-      if ((worldX << 4) + orientedX > map.maxX ||
-          (worldX << 4) + orientedX < map.minX ||
-          (worldZ << 4) + orientedZ > map.maxZ ||
-          (worldZ << 4) + orientedZ < map.minZ)
+      if (px > map.maxX || px < map.minX || pz > map.maxZ || pz < map.minZ)
         continue;
 
       for (uint8_t index = 0; index < beamNo; index++) {

--- a/src/cli/cli.cpp
+++ b/src/cli/cli.cpp
@@ -28,7 +28,9 @@ void printHelp(char *binary) {
       "  -padding int (=5)   padding to use around the image\n"
       "  -h[elp]             display an option summary\n"
       "  -v[erbose]          toggle debug mode (-vv for more)\n"
-      "  -dumpcolors         dump a json with all defined colors\n",
+      "  -dumpcolors         dump a json with all defined colors\n"
+      "  -radius VAL         radius of the circular render\n"
+      "  -centre|-center X Z coordinates of the centre of circular render\n",
       binary);
 }
 

--- a/src/include/map.hpp
+++ b/src/include/map.hpp
@@ -14,6 +14,7 @@ template <typename Integer,
           std::enable_if_t<std::is_integral<Integer>::value, int> = 0>
 struct Coordinates {
   Integer minX, maxX, minZ, maxZ;
+  Integer cenX, cenZ, radius, rsqrd;
   int16_t minY, maxY;
   Orientation orientation;
 
@@ -32,11 +33,19 @@ struct Coordinates {
     maxX = maxZ = std::numeric_limits<Integer>::min();
     minY = std::numeric_limits<int16_t>::max();
     maxY = std::numeric_limits<int16_t>::min();
+    cenX = cenZ = radius = std::numeric_limits<Integer>::max();
   }
 
   bool isUndefined() const {
     return (minX == minZ && minX == std::numeric_limits<Integer>::max() &&
             maxX == maxZ && maxX == std::numeric_limits<Integer>::min());
+  }
+
+  // Only have a circle if we have all three parts.
+  bool circleDefined() const {
+    return (cenX != std::numeric_limits<Integer>::max() &&
+            cenZ != std::numeric_limits<Integer>::max() &&
+            radius != std::numeric_limits<Integer>::max());
   }
 
   void setMaximum() {

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -24,6 +24,20 @@ bool Settings::parseArgs(int argc, char **argv, Settings::WorldOptions *opts) {
       }
       opts->boundaries.maxX = atoi(NEXTARG);
       opts->boundaries.maxZ = atoi(NEXTARG);
+    } else if (strcmp(option, "-centre") == 0 ||
+               strcmp(option, "-center") == 0) {
+      if (!MOREARGS(2) || !isNumeric(POLLARG(1)) || !isNumeric(POLLARG(2))) {
+        logger::error("{} needs two integer arguments\n", option);
+        return false;
+      }
+      opts->boundaries.cenX = atoi(NEXTARG);
+      opts->boundaries.cenZ = atoi(NEXTARG);
+    } else if (strcmp(option, "-radius") == 0) {
+      if (!MOREARGS(1) || !isNumeric(POLLARG(1))) {
+        logger::error("{} needs an integer argument\n", option);
+        return false;
+      }
+      opts->boundaries.radius = atoi(NEXTARG);
     } else if (strcmp(option, "-max") == 0) {
       if (!MOREARGS(1) || !isNumeric(POLLARG(1))) {
         logger::error("{} needs an integer argument\n", option);
@@ -121,6 +135,20 @@ bool Settings::parseArgs(int argc, char **argv, Settings::WorldOptions *opts) {
     } else {
       opts->save = SaveFile(option);
     }
+  }
+
+  if (opts->boundaries.circleDefined()) {
+    // Generate the min/max coordinates based on our centre and the radius.
+    // Add a little padding for good luck.
+    int paddedRadius = 1.2 * opts->boundaries.radius;
+
+    opts->boundaries.minX = opts->boundaries.cenX - paddedRadius;
+    opts->boundaries.maxX = opts->boundaries.cenX + paddedRadius;
+    opts->boundaries.minZ = opts->boundaries.cenZ - paddedRadius;
+    opts->boundaries.maxZ = opts->boundaries.cenZ + paddedRadius;
+
+    // We use the squared radius many times later; calculate it once here.
+    opts->boundaries.rsqrd = opts->boundaries.radius * opts->boundaries.radius;
   }
 
   if (opts->mode == RENDER) {


### PR DESCRIPTION
Add a new command line flag `-centre` (also available as `-center`) to specify the centre of a circle defined by `-radius`.  Blocks outside the radius are skipped as if they were outside `-from/-to` (which are auto-calculated from the centre + radius.)

Example usage:
```
./bin/mcmap -colors mcmap.colours.json -min 50 -max 120 -lighting -shading -centre -1059 679 -radius 80 -file village.png ~/21w08b
```
(`mcmap.colours.json` is just for deepslate/grimstone colours.)

Example output:
![village2](https://user-images.githubusercontent.com/10793/120488572-d4644900-c3ae-11eb-8a35-e397b695080a.png)


