### PR TITLE
working dockerfile for mcmap

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,30 @@
+FROM ubuntu:latest
+
+# ubuntu prompts the user if tzdata is not set ahead of time
+ENV TZ=US/Eastern
+RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
+
+# dependencies
+RUN apt update && apt install make g++ libpng-dev cmake libspdlog-dev libfmt-dev qtbase5-dev qttools5-dev -y
+
+# create user
+ENV APPUSER=mcmap
+RUN groupadd -r $APPUSER && useradd --no-log-init -r -g $APPUSER $APPUSER
+RUN mkdir /$APPUSER
+RUN mkdir /input && chown $APPUSER:$APPUSER /input
+RUN mkdir /output && chown $APPUSER:$APPUSER /output
+
+# build
+COPY . /$APPUSER
+RUN cmake -S /$APPUSER -B /$APPUSER/build
+RUN make -C /$APPUSER/build -j
+RUN ln -s /$APPUSER/build/bin/* /bin/
+
+# create a mount point for the minecraft save
+VOLUME /input
+# create a mount point to dump our image to
+VOLUME /output
+
+USER $APPUSER
+ENTRYPOINT ["mcmap"]
+CMD ["-file","/output/output.png","/input"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,7 @@
-FROM ubuntu:latest
-
-# ubuntu prompts the user if tzdata is not set ahead of time
-ENV TZ=US/Eastern
-RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
+FROM gcc:latest
 
 # dependencies
-RUN apt update && apt install make g++ libpng-dev cmake libspdlog-dev libfmt-dev qtbase5-dev qttools5-dev -y
+RUN apt update && apt install cmake libspdlog-dev libfmt-dev -y
 
 # create user
 ENV APPUSER=mcmap
@@ -17,7 +13,7 @@ RUN mkdir /output && chown $APPUSER:$APPUSER /output
 # build
 COPY . /$APPUSER
 RUN cmake -S /$APPUSER -B /$APPUSER/build
-RUN make -C /$APPUSER/build -j
+RUN make -C /$APPUSER/build mcmap
 RUN ln -s /$APPUSER/build/bin/* /bin/
 
 # create a mount point for the minecraft save


### PR DESCRIPTION
I wanted to deploy this separate to my minecraft instance so that the load of building the map didn't interfere with my game.  I'm going to do that with a docker container, so I needed mcmap available in that form.  I built this for myself, but it could be useful to others, so here you go.

I am not the best with Dockerfiles, so there may be better ways to do some of the steps I did here, but as it sits, it does work and it does output an image -- tested on a 3GB world folder.

Things I would like to improve in the future:
1. I would like to output the map to a stream or something instead of a file, but I'm not familiar enough with the code to change that.  This would remove the need for the second volume -- the output folder.
2. I would have preferred to use the `gcc` docker image as a base, but I can't find a package for debian for `qt_sinks.h` (it exists in `libspdlog-dev` on ubuntu but not on debian for some reason)

Building the docker image:
```
docker build -t mcmap:latest .
```

Running the docker container:
```
docker run --rm -v <world-folder>:/input -v <output-folder>:/output mcmap:latest
```