### PR TITLE
Fix json and mcmap-cli

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,7 @@ FIND_PACKAGE(OpenMP)
 FIND_PACKAGE(GTest)
 FIND_PACKAGE(Qt5 COMPONENTS Widgets LinguistTools)
 FIND_PACKAGE(Git)
+FIND_PACKAGE(nlohmann_json)
 
 IF (Git_FOUND)
     # Copy the git index to a random unused file to trigger a reconfigure

--- a/scripts/CMakeLists.txt
+++ b/scripts/CMakeLists.txt
@@ -1,7 +1,8 @@
 LINK_LIBRARIES(
     ZLIB::ZLIB
     fmt::fmt-header-only
-    spdlog::spdlog_header_only)
+    spdlog::spdlog_header_only
+    nlohmann_json::nlohmann_json)
 
 ADD_EXECUTABLE(json2bson json2bson.cpp)
 

--- a/scripts/json2bson.cpp
+++ b/scripts/json2bson.cpp
@@ -1,5 +1,5 @@
 #include <filesystem>
-#include <json.hpp>
+#include <nlohmann/json.hpp>
 #include <logger.hpp>
 
 std::string info =

--- a/scripts/nbt2json.cpp
+++ b/scripts/nbt2json.cpp
@@ -1,5 +1,5 @@
 #include <filesystem>
-#include <json.hpp>
+#include <nlohmann/json.hpp>
 #include <logger.hpp>
 #include <nbt/parser.hpp>
 #include <nbt/to_json.hpp>

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -32,7 +32,8 @@ TARGET_LINK_LIBRARIES(
     ZLIB::ZLIB
     PNG::PNG
     fmt::fmt-header-only
-    spdlog::spdlog_header_only)
+    spdlog::spdlog_header_only
+    nlohmann_json::nlohmann_json)
 
 IF (Git_FOUND)
     SET_SOURCE_FILES_PROPERTIES(

--- a/src/cli/CMakeLists.txt
+++ b/src/cli/CMakeLists.txt
@@ -1,6 +1,6 @@
-ADD_EXECUTABLE(mcmap cli.cpp parse.cpp)
-TARGET_LINK_LIBRARIES(mcmap mcmap_core)
+ADD_EXECUTABLE(mcmap-cli cli.cpp parse.cpp)
+TARGET_LINK_LIBRARIES(mcmap-cli mcmap_core)
 
 IF (NOT DEBUG_BUILD)
-    SET_TARGET_PROPERTIES(mcmap PROPERTIES LINK_FLAGS -s)
+    SET_TARGET_PROPERTIES(mcmap-cli PROPERTIES LINK_FLAGS -s)
 ENDIF()

--- a/src/colors.h
+++ b/src/colors.h
@@ -3,7 +3,7 @@
 
 #include "./helper.h"
 #include <filesystem>
-#include <json.hpp>
+#include <nlohmann/json.hpp>
 #include <list>
 #include <logger.hpp>
 #include <map>

--- a/src/include/nbt/to_json.hpp
+++ b/src/include/nbt/to_json.hpp
@@ -2,7 +2,7 @@
 #ifndef NBT_TO_JSON_HPP_
 #define NBT_TO_JSON_HPP_
 
-#include <json.hpp>
+#include <nlohmann/json.hpp>
 #include <nbt/nbt.hpp>
 
 using nlohmann::json;

--- a/src/savefile.h
+++ b/src/savefile.h
@@ -1,7 +1,7 @@
 #include "./helper.h"
 #include <filesystem>
 #include <fstream>
-#include <json.hpp>
+#include <nlohmann/json.hpp>
 #include <logger.hpp>
 #include <map.hpp>
 #include <nbt/parser.hpp>


### PR DESCRIPTION
- Change mcmap to mcmap-cli to match with mcmap-gui
- Change json.hpp to nlohmann/json.hpp
- Fix CMake json lib

It is now possible to use mcmap (mcmap_core) as lib:

```
cmake_minimum_required(VERSION 3.14.0)

include(FetchContent)

FetchContent_Declare(
    mcmap_core
    #GIT_REPOSITORY git@github.com:spoutn1k/mcmap.git
    #GIT_TAG        0f474f41a797ed9a32f14722e120bdfe83acd4bd

    GIT_REPOSITORY git@github.com:bensuperpc/mcmap.git
    GIT_TAG        9d181654e2c5b439a1185799e2e00e9faa9c88da
)
FetchContent_MakeAvailable(mcmap_core)
```

Signed-off-by: Bensuperpc <bensuperpc@gmail.com>