### PR TITLE
Add `DataVersion` 3465

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -5,16 +5,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - name: Install fmt manually
-      run: git clone https://github.com/fmtlib/fmt
-        && cd fmt
-        && cmake . -DFMT_TEST=FALSE
-        && sudo make -j install
-    - name: Install spdlog manually
-      run: git clone https://github.com/gabime/spdlog
-        && cd spdlog
-        && cmake .
-        && sudo make -j install
+    - name: Install dependencies
+      run: sudo apt-get install -y libfmt-dev libspdlog-dev
     - name: Compilation and execution
       uses: spoutn1k/mcmap-benchmark@cmake
     - name: Upload time data

--- a/.github/workflows/routine-exam.yml
+++ b/.github/workflows/routine-exam.yml
@@ -6,18 +6,8 @@ jobs:
     name: Unit Tests
     runs-on: ubuntu-latest
     steps:
-    - name: Install fmt manually
-      run: git clone https://github.com/fmtlib/fmt
-        && cd fmt
-        && cmake . -DFMT_TEST=FALSE
-        && sudo make -j install
-    - name: Install spdlog manually
-      run: git clone https://github.com/gabime/spdlog
-        && cd spdlog
-        && cmake .
-        && sudo make -j install
-    - name: Install gtest manually
-      run: sudo apt-get install -y libgtest-dev
+    - name: Install dependencies
+      run: sudo apt-get install -y libgtest-dev libfmt-dev libspdlog-dev
         && cd /usr/src/gtest
         && CXX=g++-10 sudo cmake CMakeLists.txt
         && sudo make -j

--- a/src/chunk.cpp
+++ b/src/chunk.cpp
@@ -8,7 +8,7 @@ namespace mcmap {
 
 namespace versions {
 std::map<int, std::function<bool(const nbt::NBT &)>> assert = {
-    {2844, assert_versions::v2844},
+    {3465, assert_versions::v3465}, {2844, assert_versions::v2844},
 #ifdef SNAPSHOT_SUPPORT
     {2840, assert_versions::v2840},
 #endif
@@ -68,14 +68,19 @@ Chunk &Chunk::operator=(Chunk &&other) {
 bool Chunk::assert_chunk(const nbt::NBT &chunk) {
   if (chunk.is_end()                     // Catch uninitialized chunks
       || !chunk.contains("DataVersion")) // Dataversion is required
+  {
+    logger::trace("Chunk is empty or invalid");
     return false;
+  }
 
   const int version = chunk["DataVersion"].get<int>();
 
   auto assert_it = compatible(versions::assert, version);
 
-  if (assert_it == versions::assert.end())
+  if (assert_it == versions::assert.end()) {
+    logger::trace("Unsupported chunk version: {}", version);
     return false;
+  }
 
   return assert_it->second(chunk);
 }

--- a/src/chunk_format_versions/assert.cpp
+++ b/src/chunk_format_versions/assert.cpp
@@ -3,6 +3,13 @@
 namespace mcmap {
 namespace versions {
 namespace assert_versions {
+bool v3465(const nbt::NBT &chunk) {
+  // Snapshot 21w43a
+  return chunk.contains("sections")  // No sections mean no blocks
+         && chunk.contains("Status") // Ensure the status is `minecraft:full`
+         && chunk["Status"].get<nbt::NBT::tag_string_t>() == "minecraft:full";
+}
+
 bool v2844(const nbt::NBT &chunk) {
   // Snapshot 21w43a
   return chunk.contains("sections")  // No sections mean no blocks

--- a/src/chunk_format_versions/assert.hpp
+++ b/src/chunk_format_versions/assert.hpp
@@ -3,6 +3,8 @@
 namespace mcmap {
 namespace versions {
 namespace assert_versions {
+bool v3465(const nbt::NBT &chunk);
+
 bool v2844(const nbt::NBT &chunk);
 
 #ifdef SNAPSHOT_SUPPORT

--- a/src/worldloader.cpp
+++ b/src/worldloader.cpp
@@ -97,6 +97,8 @@ void Data::loadChunk(const ChunkCoordinates coords) {
 
   if (!nbt::parse(chunkBuffer, length, data) || !Chunk::assert_chunk(data)) {
     fclose(regionHandle);
+    logger::trace("Chunk parsing failed for chunk {} {} in {}", coords.x,
+                  coords.z, regionFile.c_str());
     return;
   }
 
@@ -121,8 +123,10 @@ const Data::Chunk &Data::chunkAt(const ChunkCoordinates coords,
   }
 
   auto query = chunks.find(coords);
-  if (query == chunks.end())
+  if (query == chunks.end()) {
+    logger::trace("Chunk loading failed for {} {}", coords.x, coords.z);
     return empty_chunk;
+  }
 
   return query->second;
 }


### PR DESCRIPTION
Mojang keeps changing the internal names of variables in the save files. This checks for the `minecraft:full` status instead of `full` in chunks where the DataVersion is >= 3465.

Fixes #94.