### PR TITLE
Add short_grass

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,6 @@ src/include/fmt/format.h
 src/include/fmt/format-inl.h
 src/include/fmt/color.h
 src/include/fmt/format.cc
-extracted_blocks/
 
 # Tools byproducts
 .gdb_history

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ src/include/fmt/format.h
 src/include/fmt/format-inl.h
 src/include/fmt/color.h
 src/include/fmt/format.cc
+extracted_blocks/
 
 # Tools byproducts
 .gdb_history

--- a/scripts/average.sh
+++ b/scripts/average.sh
@@ -5,6 +5,39 @@
 
 set -eo pipefail
 
+install_imagemagick() {
+  if ! command -v convert &>/dev/null; then
+    if [[ "${UNAME}" == "Darwin" ]] && command -v brew &>/dev/null; then
+      brew install imagemagick
+    fi
+  fi
+}
+
+unpack_minecraft_jar() {
+  if [[ -z "${MINECRAFT_VER}" ]]; then
+    return
+  fi
+
+  if [[ -f "extracted_blocks/${MINECRAFT_VER}/assets/minecraft/textures/block/dirt.png" ]]; then
+    return
+  fi
+
+  if [[ "${UNAME}" == "Darwin" ]]; then
+    jar_file="${HOME}/Library/Application Support/minecraft/versions/${MINECRAFT_VER}/${MINECRAFT_VER}.jar"
+  fi
+
+  if [[ -n "${jar_file}" ]]; then
+    mkdir -p "extracted_blocks/${MINECRAFT_VER}"
+    pushd "extracted_blocks/${MINECRAFT_VER}"
+    jar xf "${jar_file}" assets/minecraft/textures/block
+    popd
+  fi
+}
+
+install_imagemagick
+unpack_minecraft_jar
+
 printf '%s\t%s\n' \
-  "$(basename "${1}")" \
-  "$(convert "${1}" -resize 1x1 txt:- | grep -Po "#[[:xdigit:]]{6}" | tr A-F a-f)"
+  "$(basename "extracted_blocks/${MINECRAFT_VER}/assets/minecraft/textures/block/${1}.png")" \
+  "$(convert "extracted_blocks/${MINECRAFT_VER}/assets/minecraft/textures/block/${1}.png" -resize 1x1 txt:- \
+    | grep -o "#[[:xdigit:]]\{6\}" | tr A-F a-f)"

--- a/scripts/average.sh
+++ b/scripts/average.sh
@@ -5,7 +5,7 @@
 
 set -eo pipefail
 
-SYSTEM=$(uname)
+SYSTEM="$(uname)"
 EXTRACTDIR=/tmp/extracted_blocks
 
 macos::install_deps() {
@@ -18,11 +18,11 @@ macos::install_deps() {
 }
 
 macos::mc_home() {
-  echo "$HOME/Library/Application Support/minecraft/versions"
+  echo $HOME/Library/Application Support/minecraft/versions
 }
 
 linux::mc_home() {
-  echo "$HOME/.minecraft/versions"
+  echo $HOME/.minecraft/versions
 }
 
 unpack_assets() {
@@ -50,7 +50,7 @@ unpack_assets() {
 }
 
 average() {
-  FILE=$1
+  FILE="$1"
   EXTRACTED="$EXTRACTDIR/$MINECRAFT_VER/assets/minecraft/textures/block/$1.png"
   if [[ -f "$EXTRACTED" ]] ; then
       FILE="$EXTRACTED"
@@ -73,4 +73,4 @@ if [[ "$SYSTEM" == Darwin ]] ; then
   fi
 fi
 
-average $1
+average "$1"

--- a/src/colors.json
+++ b/src/colors.json
@@ -812,6 +812,7 @@
   "minecraft:sea_lantern": "#90b8ad",
   "minecraft:sea_pickle": { "color": "#4e531dfe", "type": "Head" },
   "minecraft:seagrass": { "color": "#389306fe", "type": "UnderwaterPlant" },
+  "minecraft:short_grass": { "color": "#426539fe", "type": "Plant" },
   "minecraft:shroomlight": "#f2974c",
   "minecraft:shulker_box": "#8535c3",
   "minecraft:skeleton_skull": { "color": "#969696fe", "type": "Head" },


### PR DESCRIPTION
`grass` was renamed to `short_grass` in 1.20.4 (https://minecraft.wiki/w/Short_Grass#Data_history) - there are more blocks, but they are not yet officially released.

I also added some automation to the script especially for macOS users, as I keep forgetting how to use the script :P